### PR TITLE
Fix placeholder repository URLs in package.json files

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend",
+    "directory": "packages/example"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,11 +6,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-org/soroban-resurrect",
+    "url": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend",
     "directory": "packages/react"
   },
-  "homepage": "https://github.com/your-org/soroban-resurrect#readme",
-  "bugs": "https://github.com/your-org/soroban-resurrect/issues",
+  "homepage": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend#readme",
+  "bugs": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend/issues",
   "keywords": [
     "stellar",
     "soroban",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-org/soroban-resurrect",
+    "url": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend",
     "directory": "packages/sdk"
   },
   "homepage": "https://github.com/your-org/soroban-resurrect#readme",


### PR DESCRIPTION
Closes #2\n\nUpdates all three package.json files to use the correct repository URL instead of the 'your-org' placeholder:\n- packages/sdk/package.json\n- packages/react/package.json\n- packages/example/package.json