### PR TITLE
Add code coverage reporting to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
 
       - run: npm run test
 
+      - name: Coverage (SDK)
+        working-directory: packages/sdk
+        run: npx vitest run --coverage --coverage.thresholds.lines=80
+
+      - name: Coverage (React)
+        working-directory: packages/react
+        run: npx vitest run --coverage --coverage.thresholds.lines=80
+
       - run: npx tsc --noEmit -p packages/sdk/tsconfig.json
       - run: npx tsc --noEmit -p packages/react/tsconfig.json
 

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -7,5 +7,16 @@ export default defineConfig({
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
     setupFiles: ['tests/setup.ts'],
     css: false,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'html'],
+      include: ['src/**/*.ts', 'src/**/*.tsx'],
+      thresholds: {
+        lines: 80,
+        branches: 70,
+        functions: 75,
+        statements: 80,
+      },
+    },
   },
 })

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -5,5 +5,16 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'html'],
+      include: ['src/**/*.ts'],
+      thresholds: {
+        lines: 80,
+        branches: 70,
+        functions: 75,
+        statements: 80,
+      },
+    },
   },
 })


### PR DESCRIPTION
Closes #4\n\nAdds vitest coverage configuration with thresholds (lines: 80%, branches: 70%, functions: 75%) to both SDK and React packages. CI now runs coverage checks after tests.