### PR TITLE
chore(deps): audit fixes; quiet test stderr; update Dependabot config and README

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
       stellar-sdk:
         patterns:
           - "@stellar/stellar-sdk"
-          - "@stellar/stellar-base"
       testing:
         patterns:
           - "vitest"

--- a/README.md
+++ b/README.md
@@ -99,3 +99,18 @@ npm run build       # Build all packages
 npm run test        # Run SDK tests
 npm run example     # Start example app
 ```
+
+## Developer notes
+
+- Node: `>=18` is required (see `packages/*/package.json` engines).
+- To run the full test matrix including integration tests (if available):
+
+```bash
+npm ci
+npm run test --workspaces
+npm run test -w packages/sdk --if-present # integration tests via vitest config
+```
+
+- Dependencies: run `npm audit` and `npm audit fix` regularly. Dependabot is enabled (weekly) to keep deps up-to-date.
+
+- CI: ensure CI uses Node 18+ and consider adding `npm audit` to the CI pipeline or a scheduled job.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1886,16 +1886,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/packages/react/tests/useSorobanResurrect.test.tsx
+++ b/packages/react/tests/useSorobanResurrect.test.tsx
@@ -412,8 +412,10 @@ describe('SorobanResurrectProvider + useSorobanResurrectContext', () => {
       return null
     }
 
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     expect(() => render(<BadComponent />)).toThrow(
       'useSorobanResurrectContext must be used within a <SorobanResurrectProvider>',
     )
+    spy.mockRestore()
   })
 })


### PR DESCRIPTION
closes #40 
closes #39 
closes #38 
closes #37 


This PR:

- Runs `npm audit fix` non-force to address vulnerabilities and updates the lockfile.
- Suppresses noisy jsdom error logs in the React test that intentionally throws (`packages/react/tests/useSorobanResurrect.test.tsx`).
- Removes `@stellar/stellar-base` from Dependabot grouping (we use `@stellar/stellar-sdk`).
- Adds developer notes to `README.md` (Node version, test commands, audit guidance).

All tests pass locally (`npm test --workspaces`).

If you'd like, I can follow up with a separate PR that runs `npm audit fix --force` and upgrades major breaking packages, or add an automated Dependabot config change.