### PR TITLE
feat(sdk): add SAC ContractData and ContractInstance support

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -21,3 +21,76 @@ const client = new SorobanResurrect({
 const { needsRestoration, restoreTransactionXDR } =
   await client.checkAndPrepare(txXDR, sourceAccount)
 ```
+
+## Stellar Asset Contract (SAC) Support
+
+Stellar Asset Contracts (SACs) are system contracts for classic Stellar assets
+(e.g. native XLM and issued tokens). Their ledger entries have key structures
+that differ from ordinary WASM contracts. This SDK handles them transparently.
+
+### SAC ledger entry types
+
+Each SAC stores multiple `ContractData` entries per user, keyed by `ScVal`:
+
+| Entry | Key shape | `sacKeyType` |
+|-------|-----------|--------------|
+| Token balance | `scvVec([scvSymbol("Balance"), scvAddress(account)])` | `sacBalance` |
+| Spend allowance | `scvVec([scvSymbol("Allowance"), scvMap([from, spender])])` | `sacAllowance` |
+| Administrator | `scvSymbol("Admin")` | `sacAdmin` |
+| Replay nonce | `scvLedgerKeyNonce(...)` | `sacNonce` |
+| Token metadata | `scvSymbol("Name"\|"Symbol"\|"Decimals")` | `sacMetadata` |
+| Contract instance | `scvLedgerKeyContractInstance()` — `keyType: "contractInstance"` | – |
+
+All of these are restored with the same `RestoreFootprint` operation as any
+other Soroban ledger entry.
+
+### Inspecting SAC archived keys
+
+After calling `checkAndPrepare` or `simulate`, inspect `archivedKeys` to see
+SAC-specific metadata:
+
+```typescript
+const { archivedKeys } = await client.simulate(txXDR)
+
+for (const key of archivedKeys) {
+  if (key.keyType === 'contractInstance') {
+    console.log(`Contract instance archived for ${key.contractId}`)
+  }
+  if (key.keyType === 'contractData' && key.sacKeyType) {
+    console.log(`SAC entry archived: ${key.sacKeyType} (contract ${key.contractId})`)
+    // sacKeyType is one of: sacBalance, sacAllowance, sacAdmin, sacNonce, sacMetadata
+  }
+}
+```
+
+### Restoration order — ContractInstance must come first
+
+When a contract's *instance* entry is archived, all of its `ContractData`
+entries become inaccessible.  The SDK automatically sorts archived keys by
+`restorePriority` before building the restore transaction:
+
+| `keyType` | `restorePriority` | Restored |
+|-----------|-------------------|---------|
+| `contractInstance` | **0** | first |
+| `contractCode` | 1 | second |
+| `contractData` (incl. SAC) | 2 | third |
+| `ttlEntry` / `unknown` | 3 | last |
+
+You can read the priority from the `ArchivedKey` object:
+
+```typescript
+const sorted = archivedKeys.sort((a, b) => a.restorePriority - b.restorePriority)
+```
+
+### Detecting whether a SAC key is a custom type
+
+The `classifySacKey` helper is exported for advanced use cases where you want
+to inspect a raw `ScVal` key outside of the normal `simulate` flow:
+
+```typescript
+import { classifySacKey } from '@soroban-resurrect/sdk'
+
+const sacType = classifySacKey(scVal) // 'sacBalance' | 'sacAllowance' | ... | undefined
+```
+
+Returns `undefined` when the `ScVal` does not match any known SAC pattern.

--- a/packages/sdk/src/footprint-parser.ts
+++ b/packages/sdk/src/footprint-parser.ts
@@ -2,6 +2,7 @@ import {
   xdr,
   TransactionBuilder,
 } from '@stellar/stellar-sdk'
+import type { ArchivedKey, RestorePriority, SacKeyType } from './types.js'
 
 export interface FootprintKeys {
   readOnly: xdr.LedgerKey[]
@@ -19,25 +20,143 @@ export function extractKeysFromFootprint(footprint: xdr.LedgerFootprint): Footpr
   }
 }
 
+// ---------------------------------------------------------------------------
+// SAC key detection
+// ---------------------------------------------------------------------------
+
+/**
+ * SAC-specific `ScVal` type discriminants (stable across all stellar-sdk v12 builds).
+ *
+ * scvSymbol              = 15
+ * scvVec                 = 16
+ * scvLedgerKeyNonce      = 21
+ * scvLedgerKeyContractInstance = 20
+ */
+const SCV_SYMBOL = 15
+const SCV_VEC = 16
+const SCV_LEDGER_KEY_NONCE = 21
+const SCV_LEDGER_KEY_CONTRACT_INSTANCE = 20
+
+/**
+ * SAC token symbols that appear as the first element of a `scvVec` key or as a
+ * standalone `scvSymbol` key.
+ */
+const SAC_VEC_SYMBOLS = new Set(['Balance', 'Allowance'])
+const SAC_SYMBOL_KEYS = new Set(['Admin', 'Name', 'Symbol', 'Decimals'])
+
+/**
+ * Attempt to determine the SAC-specific sub-key type from the `ScVal` key of a
+ * `ContractData` ledger entry.
+ *
+ * SAC (Stellar Asset Contract) stores the following entries:
+ *
+ * | Key shape                                           | sacKeyType    |
+ * |-----------------------------------------------------|---------------|
+ * | `scvVec([ scvSymbol("Balance"), scvAddress(...) ])` | sacBalance    |
+ * | `scvVec([ scvSymbol("Allowance"), scvMap(...) ])`   | sacAllowance  |
+ * | `scvLedgerKeyNonce(...)`                            | sacNonce      |
+ * | `scvSymbol("Admin")`                                | sacAdmin      |
+ * | `scvSymbol("Name"|"Symbol"|"Decimals")`             | sacMetadata   |
+ *
+ * Returns `undefined` when the key does not match any known SAC pattern.
+ */
+export function classifySacKey(dataKey: xdr.ScVal): SacKeyType | undefined {
+  try {
+    const typeVal: number = dataKey.switch().value
+
+    // scvLedgerKeyNonce → nonce
+    if (typeVal === SCV_LEDGER_KEY_NONCE) {
+      return 'sacNonce'
+    }
+
+    // scvLedgerKeyContractInstance → handled at the LedgerKey level, not here
+    if (typeVal === SCV_LEDGER_KEY_CONTRACT_INSTANCE) {
+      return undefined // instance entries are classified at classifyLedgerKey level
+    }
+
+    // scvSymbol("Admin"|"Name"|"Symbol"|"Decimals")
+    if (typeVal === SCV_SYMBOL) {
+      const sym: string = dataKey.value().toString()
+      if (sym === 'Admin') return 'sacAdmin'
+      if (SAC_SYMBOL_KEYS.has(sym)) return 'sacMetadata'
+      return undefined
+    }
+
+    // scvVec([ scvSymbol("Balance"|"Allowance"), ... ])
+    if (typeVal === SCV_VEC) {
+      const vec: xdr.ScVal[] = dataKey.value() as xdr.ScVal[]
+      if (Array.isArray(vec) && vec.length >= 1) {
+        const head = vec[0]
+        if (head.switch().value === SCV_SYMBOL) {
+          const sym: string = head.value().toString()
+          if (sym === 'Balance') return 'sacBalance'
+          if (sym === 'Allowance') return 'sacAllowance'
+        }
+      }
+      return undefined
+    }
+
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LedgerKey classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a `LedgerKey` by entry type and, for `ContractData` entries, detect
+ * whether it belongs to a Stellar Asset Contract and which SAC sub-type it is.
+ *
+ * For `ContractInstance` entries (stored as `ContractData` with a
+ * `scvLedgerKeyContractInstance` key value), the returned `keyType` is
+ * `"contractInstance"` and `restorePriority` is `0` so they are sent to the
+ * chain before their dependent data entries.
+ */
 export function classifyLedgerKey(key: xdr.LedgerKey): {
-  keyType: 'contractData' | 'contractCode' | 'ttlEntry' | 'unknown'
+  keyType: ArchivedKey['keyType']
+  sacKeyType?: SacKeyType
   contractId?: string
+  restorePriority: RestorePriority
 } {
   switch (key.switch()) {
     case xdr.LedgerEntryType.contractData(): {
       const data = key.contractData()
       const contractId = data.contract().contractId()?.toString('hex')
-      return { keyType: 'contractData', contractId }
+      const dataKey: xdr.ScVal = data.key()
+
+      // ContractInstance entry: the key is scvLedgerKeyContractInstance
+      if (dataKey.switch().value === SCV_LEDGER_KEY_CONTRACT_INSTANCE) {
+        return {
+          keyType: 'contractInstance',
+          contractId,
+          restorePriority: 0,
+        }
+      }
+
+      // Try to identify SAC-specific sub-type
+      const sacKeyType = classifySacKey(dataKey)
+      return {
+        keyType: 'contractData',
+        sacKeyType,
+        contractId,
+        restorePriority: 2,
+      }
     }
+
     case xdr.LedgerEntryType.contractCode(): {
       const code = key.contractCode()
       const contractId = code.hash().toString('hex')
-      return { keyType: 'contractCode', contractId }
+      return { keyType: 'contractCode', contractId, restorePriority: 1 }
     }
+
     case xdr.LedgerEntryType.ttl():
-      return { keyType: 'ttlEntry' }
+      return { keyType: 'ttlEntry', restorePriority: 3 }
+
     default:
-      return { keyType: 'unknown' }
+      return { keyType: 'unknown', restorePriority: 3 }
   }
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,7 @@ export { SorobanResurrect } from './soroban-resurrect.js'
 export {
   extractKeysFromFootprint,
   classifyLedgerKey,
+  classifySacKey,
   encodeLedgerKey,
   extractFootprintFromTransaction,
 } from './footprint-parser.js'
@@ -11,6 +12,8 @@ export {
 } from './types.js'
 export type {
   ArchivedKey,
+  SacKeyType,
+  RestorePriority,
   SorobanResurrectConfig,
   SimulationCheckResult,
   RestoreTransactionResult,

--- a/packages/sdk/src/soroban-resurrect.ts
+++ b/packages/sdk/src/soroban-resurrect.ts
@@ -171,6 +171,12 @@ export class SorobanResurrect {
       }
     }
 
+    // Sort by restorePriority so contractInstance (0) entries come before
+    // contractCode (1) and contractData (2) entries.  This guarantees that a
+    // contract's instance is live before we attempt to restore its data, which
+    // is required by the Soroban VM (issue #48).
+    archivedKeys.sort((a, b) => a.restorePriority - b.restorePriority)
+
     return {
       needsRestoration: archivedKeys.length > 0,
       archivedKeys,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,10 +1,63 @@
 import { xdr } from '@stellar/stellar-sdk'
 
+/**
+ * SAC (Stellar Asset Contract) specific key types.
+ *
+ * SAC tokens store per-user state in `ContractData` ledger entries whose XDR key
+ * is an `ScVal` with predictable shape:
+ *
+ * | sacKeyType      | ScVal shape                                                         |
+ * |-----------------|---------------------------------------------------------------------|
+ * | `sacBalance`    | `scvVec([ scvSymbol("Balance"), scvAddress(account) ])`             |
+ * | `sacAllowance`  | `scvVec([ scvSymbol("Allowance"), scvMap([from, spender]) ])`       |
+ * | `sacNonce`      | `scvLedgerKeyNonce` (ScNonceKey)                                    |
+ * | `sacAdmin`      | `scvSymbol("Admin")`                                                |
+ * | `sacMetadata`   | `scvSymbol("Name"|"Symbol"|"Decimals")`                             |
+ */
+export type SacKeyType = 'sacBalance' | 'sacAllowance' | 'sacNonce' | 'sacAdmin' | 'sacMetadata'
+
+/**
+ * Restoration priority order.
+ *
+ * Contract instance entries **must** be restored before their contract data
+ * entries become accessible, so they carry a lower numeric priority value
+ * (restored first).
+ *
+ * | priority | meaning                                      |
+ * |----------|----------------------------------------------|
+ * | 0        | contractInstance – restore first             |
+ * | 1        | contractCode    – restore second             |
+ * | 2        | contractData    – restore last               |
+ * | 3        | other / unknown – restore last               |
+ */
+export type RestorePriority = 0 | 1 | 2 | 3
+
 export interface ArchivedKey {
   key: xdr.LedgerKey
   keyBase64: string
-  keyType: 'contractData' | 'contractCode' | 'ttlEntry' | 'unknown'
+  /**
+   * High-level entry type classification.
+   *
+   * - `contractInstance` – the contract's own instance entry (new, issue #48)
+   * - `contractData`     – generic contract data (includes SAC entries, issue #47)
+   * - `contractCode`     – the contract's WASM bytecode entry
+   * - `ttlEntry`         – a TTL / expiry ledger entry
+   * - `unknown`          – unrecognised entry type
+   */
+  keyType: 'contractInstance' | 'contractData' | 'contractCode' | 'ttlEntry' | 'unknown'
+  /**
+   * SAC-specific sub-classification, only present when `keyType === 'contractData'`
+   * and the entry belongs to a Stellar Asset Contract.
+   */
+  sacKeyType?: SacKeyType
+  /** Hex-encoded contract ID, when available. */
   contractId?: string
+  /**
+   * Restoration priority — lower numbers should be restored first.
+   * `contractInstance` entries always have priority 0 so they are sent to the
+   * chain before any dependent `contractData` entries.
+   */
+  restorePriority: RestorePriority
 }
 
 export interface SorobanResurrectConfig {

--- a/packages/sdk/tests/sac-contract-data.test.ts
+++ b/packages/sdk/tests/sac-contract-data.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for SAC (Stellar Asset Contract) key detection and classification.
+ *
+ * Covers issues #47 (SAC ContractData key support) and #48 (ContractInstance
+ * handling with priority restoration).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { classifyLedgerKey, classifySacKey } from '../src/footprint-parser.js'
+import { xdr } from '@stellar/stellar-sdk'
+
+// ---------------------------------------------------------------------------
+// Mock stellar-sdk to keep tests hermetic
+// ---------------------------------------------------------------------------
+
+vi.mock('@stellar/stellar-sdk', () => {
+  /**
+   * Minimal ScVal-alike that carries a numeric type discriminant and an
+   * optional value, mirroring the real XDR union.
+   */
+  class MockScVal {
+    private _typeValue: number
+    private _val: unknown
+
+    constructor(typeValue: number, val?: unknown) {
+      this._typeValue = typeValue
+      this._val = val
+    }
+
+    switch() {
+      return { value: this._typeValue, name: `type_${this._typeValue}` }
+    }
+
+    value() {
+      return this._val
+    }
+  }
+
+  // ScValType numeric constants (from actual stellar-sdk)
+  const SCV_SYMBOL = 15
+  const SCV_VEC = 16
+  const SCV_LEDGER_KEY_NONCE = 21
+  const SCV_LEDGER_KEY_CONTRACT_INSTANCE = 20
+
+  const scvSymbol = (s: string) => new MockScVal(SCV_SYMBOL, Buffer.from(s))
+  const scvVec = (items: MockScVal[]) => new MockScVal(SCV_VEC, items)
+  const scvLedgerKeyContractInstance = () => new MockScVal(SCV_LEDGER_KEY_CONTRACT_INSTANCE)
+  const scvLedgerKeyNonce = () => new MockScVal(SCV_LEDGER_KEY_NONCE, {})
+
+  const makeLedgerKey = (entryType: string, overrides: Record<string, () => unknown> = {}) => ({
+    switch: () => entryType,
+    contractData: () => ({
+      contract: () => ({ contractId: () => Buffer.from('cafebabe', 'hex') }),
+      key: overrides.key ?? (() => scvLedgerKeyContractInstance()),
+      durability: () => ({ value: 1 }), // persistent
+    }),
+    contractCode: () => ({
+      hash: () => Buffer.from('deadbeef', 'hex'),
+    }),
+    ...overrides,
+  })
+
+  return {
+    xdr: {
+      LedgerEntryType: {
+        contractData: () => 'contractData',
+        contractCode: () => 'contractCode',
+        ttl: () => 'ttl',
+      },
+      ScValType: {
+        scvSymbol: () => ({ value: SCV_SYMBOL }),
+        scvVec: () => ({ value: SCV_VEC }),
+        scvLedgerKeyNonce: () => ({ value: SCV_LEDGER_KEY_NONCE }),
+        scvLedgerKeyContractInstance: () => ({ value: SCV_LEDGER_KEY_CONTRACT_INSTANCE }),
+      },
+      ScVal: {
+        scvSymbol,
+        scvVec,
+        scvLedgerKeyContractInstance,
+        scvLedgerKeyNonce,
+      },
+      // Expose helpers for test construction
+      _makeLedgerKey: makeLedgerKey,
+      _scvSymbol: scvSymbol,
+      _scvVec: scvVec,
+      _scvLedgerKeyContractInstance: scvLedgerKeyContractInstance,
+      _scvLedgerKeyNonce: scvLedgerKeyNonce,
+    },
+    SorobanRpc: { Server: vi.fn(), Api: {} },
+    TransactionBuilder: { fromXDR: vi.fn() },
+    Transaction: vi.fn(),
+    Operation: { restoreFootprint: vi.fn() },
+    Account: vi.fn(),
+    BASE_FEE: '100',
+    SorobanDataBuilder: vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Helpers — build mock LedgerKey objects with custom ScVal keys
+// ---------------------------------------------------------------------------
+
+function makeContractDataKey(scVal: unknown): xdr.LedgerKey {
+  return (xdr as any)._makeLedgerKey('contractData', {
+    key: () => scVal,
+  }) as unknown as xdr.LedgerKey
+}
+
+function makeContractCodeKey(): xdr.LedgerKey {
+  return (xdr as any)._makeLedgerKey('contractCode') as unknown as xdr.LedgerKey
+}
+
+function makeTtlKey(): xdr.LedgerKey {
+  return (xdr as any)._makeLedgerKey('ttl') as unknown as xdr.LedgerKey
+}
+
+function makeUnknownKey(): xdr.LedgerKey {
+  return (xdr as any)._makeLedgerKey('account') as unknown as xdr.LedgerKey
+}
+
+// ---------------------------------------------------------------------------
+// classifySacKey unit tests (issue #47)
+// ---------------------------------------------------------------------------
+
+describe('classifySacKey', () => {
+  it('identifies Balance keys (scvVec with scvSymbol("Balance") as first element)', () => {
+    const balanceScVal = (xdr as any)._scvVec([
+      (xdr as any)._scvSymbol('Balance'),
+      (xdr as any)._scvSymbol('some-address'), // simplified stand-in for scvAddress
+    ])
+    expect(classifySacKey(balanceScVal as unknown as xdr.ScVal)).toBe('sacBalance')
+  })
+
+  it('identifies Allowance keys (scvVec with scvSymbol("Allowance") as first element)', () => {
+    const allowanceScVal = (xdr as any)._scvVec([
+      (xdr as any)._scvSymbol('Allowance'),
+    ])
+    expect(classifySacKey(allowanceScVal as unknown as xdr.ScVal)).toBe('sacAllowance')
+  })
+
+  it('identifies Admin keys (scvSymbol("Admin"))', () => {
+    const adminScVal = (xdr as any)._scvSymbol('Admin')
+    expect(classifySacKey(adminScVal as unknown as xdr.ScVal)).toBe('sacAdmin')
+  })
+
+  it('identifies Name metadata key (scvSymbol("Name"))', () => {
+    const nameScVal = (xdr as any)._scvSymbol('Name')
+    expect(classifySacKey(nameScVal as unknown as xdr.ScVal)).toBe('sacMetadata')
+  })
+
+  it('identifies Symbol metadata key (scvSymbol("Symbol"))', () => {
+    const symScVal = (xdr as any)._scvSymbol('Symbol')
+    expect(classifySacKey(symScVal as unknown as xdr.ScVal)).toBe('sacMetadata')
+  })
+
+  it('identifies Decimals metadata key (scvSymbol("Decimals"))', () => {
+    const decimalsScVal = (xdr as any)._scvSymbol('Decimals')
+    expect(classifySacKey(decimalsScVal as unknown as xdr.ScVal)).toBe('sacMetadata')
+  })
+
+  it('identifies Nonce keys (scvLedgerKeyNonce)', () => {
+    const nonceScVal = (xdr as any)._scvLedgerKeyNonce()
+    expect(classifySacKey(nonceScVal as unknown as xdr.ScVal)).toBe('sacNonce')
+  })
+
+  it('returns undefined for scvLedgerKeyContractInstance (classified at LedgerKey level)', () => {
+    const instanceScVal = (xdr as any)._scvLedgerKeyContractInstance()
+    expect(classifySacKey(instanceScVal as unknown as xdr.ScVal)).toBeUndefined()
+  })
+
+  it('returns undefined for non-SAC vec keys', () => {
+    const unknownVec = (xdr as any)._scvVec([
+      (xdr as any)._scvSymbol('SomeOtherStorage'),
+    ])
+    expect(classifySacKey(unknownVec as unknown as xdr.ScVal)).toBeUndefined()
+  })
+
+  it('returns undefined for non-SAC symbol keys', () => {
+    const randomSym = (xdr as any)._scvSymbol('RandomKey')
+    expect(classifySacKey(randomSym as unknown as xdr.ScVal)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// classifyLedgerKey extended tests (issues #47 and #48)
+// ---------------------------------------------------------------------------
+
+describe('classifyLedgerKey — contractInstance entries (issue #48)', () => {
+  it('classifies ContractData with scvLedgerKeyContractInstance key as contractInstance', () => {
+    const instanceKey = makeContractDataKey((xdr as any)._scvLedgerKeyContractInstance())
+    const result = classifyLedgerKey(instanceKey)
+    expect(result.keyType).toBe('contractInstance')
+    expect(result.restorePriority).toBe(0)
+    expect(result.contractId).toBe('cafebabe')
+    expect(result.sacKeyType).toBeUndefined()
+  })
+
+  it('assigns restorePriority 0 to contractInstance entries', () => {
+    const instanceKey = makeContractDataKey((xdr as any)._scvLedgerKeyContractInstance())
+    const result = classifyLedgerKey(instanceKey)
+    expect(result.restorePriority).toBe(0)
+  })
+})
+
+describe('classifyLedgerKey — SAC ContractData entries (issue #47)', () => {
+  it('classifies Balance entry with sacKeyType=sacBalance', () => {
+    const balanceKey = makeContractDataKey(
+      (xdr as any)._scvVec([(xdr as any)._scvSymbol('Balance')]),
+    )
+    const result = classifyLedgerKey(balanceKey)
+    expect(result.keyType).toBe('contractData')
+    expect(result.sacKeyType).toBe('sacBalance')
+    expect(result.restorePriority).toBe(2)
+  })
+
+  it('classifies Allowance entry with sacKeyType=sacAllowance', () => {
+    const allowanceKey = makeContractDataKey(
+      (xdr as any)._scvVec([(xdr as any)._scvSymbol('Allowance')]),
+    )
+    const result = classifyLedgerKey(allowanceKey)
+    expect(result.keyType).toBe('contractData')
+    expect(result.sacKeyType).toBe('sacAllowance')
+  })
+
+  it('classifies Admin entry with sacKeyType=sacAdmin', () => {
+    const adminKey = makeContractDataKey((xdr as any)._scvSymbol('Admin'))
+    const result = classifyLedgerKey(adminKey)
+    expect(result.keyType).toBe('contractData')
+    expect(result.sacKeyType).toBe('sacAdmin')
+  })
+
+  it('classifies Name metadata entry with sacKeyType=sacMetadata', () => {
+    const nameKey = makeContractDataKey((xdr as any)._scvSymbol('Name'))
+    const result = classifyLedgerKey(nameKey)
+    expect(result.keyType).toBe('contractData')
+    expect(result.sacKeyType).toBe('sacMetadata')
+  })
+
+  it('classifies Nonce entry with sacKeyType=sacNonce', () => {
+    const nonceKey = makeContractDataKey((xdr as any)._scvLedgerKeyNonce())
+    const result = classifyLedgerKey(nonceKey)
+    expect(result.keyType).toBe('contractData')
+    expect(result.sacKeyType).toBe('sacNonce')
+  })
+
+  it('classifies non-SAC contractData entries without sacKeyType', () => {
+    const customKey = makeContractDataKey((xdr as any)._scvSymbol('CustomStorage'))
+    const result = classifyLedgerKey(customKey)
+    expect(result.keyType).toBe('contractData')
+    expect(result.sacKeyType).toBeUndefined()
+  })
+
+  it('assigns restorePriority 2 to all contractData entries', () => {
+    const balanceKey = makeContractDataKey(
+      (xdr as any)._scvVec([(xdr as any)._scvSymbol('Balance')]),
+    )
+    expect(classifyLedgerKey(balanceKey).restorePriority).toBe(2)
+  })
+})
+
+describe('classifyLedgerKey — contractCode entries', () => {
+  it('classifies contractCode keys correctly', () => {
+    const result = classifyLedgerKey(makeContractCodeKey())
+    expect(result.keyType).toBe('contractCode')
+    expect(result.contractId).toBe('deadbeef')
+    expect(result.restorePriority).toBe(1)
+    expect(result.sacKeyType).toBeUndefined()
+  })
+})
+
+describe('classifyLedgerKey — ttl and unknown entries', () => {
+  it('classifies ttl entries with priority 3', () => {
+    const result = classifyLedgerKey(makeTtlKey())
+    expect(result.keyType).toBe('ttlEntry')
+    expect(result.restorePriority).toBe(3)
+  })
+
+  it('classifies unknown entry types with priority 3', () => {
+    const result = classifyLedgerKey(makeUnknownKey())
+    expect(result.keyType).toBe('unknown')
+    expect(result.restorePriority).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Restoration priority ordering tests (issue #48)
+// ---------------------------------------------------------------------------
+
+describe('restoration priority ordering', () => {
+  it('contractInstance has lower priority number than contractCode', () => {
+    const instanceKey = makeContractDataKey((xdr as any)._scvLedgerKeyContractInstance())
+    const codeKey = makeContractCodeKey()
+    const instanceResult = classifyLedgerKey(instanceKey)
+    const codeResult = classifyLedgerKey(codeKey)
+    expect(instanceResult.restorePriority).toBeLessThan(codeResult.restorePriority)
+  })
+
+  it('contractCode has lower priority number than contractData', () => {
+    const codeKey = makeContractCodeKey()
+    const dataKey = makeContractDataKey((xdr as any)._scvSymbol('Admin'))
+    const codeResult = classifyLedgerKey(codeKey)
+    const dataResult = classifyLedgerKey(dataKey)
+    expect(codeResult.restorePriority).toBeLessThan(dataResult.restorePriority)
+  })
+
+  it('sorts a mixed batch by restorePriority ascending', () => {
+    const keys = [
+      { restorePriority: 2, keyType: 'contractData' as const, key: {} as xdr.LedgerKey, keyBase64: 'b' },
+      { restorePriority: 0, keyType: 'contractInstance' as const, key: {} as xdr.LedgerKey, keyBase64: 'a' },
+      { restorePriority: 1, keyType: 'contractCode' as const, key: {} as xdr.LedgerKey, keyBase64: 'c' },
+      { restorePriority: 3, keyType: 'ttlEntry' as const, key: {} as xdr.LedgerKey, keyBase64: 'd' },
+    ]
+    const sorted = [...keys].sort((a, b) => a.restorePriority - b.restorePriority)
+    expect(sorted.map(k => k.keyType)).toEqual([
+      'contractInstance',
+      'contractCode',
+      'contractData',
+      'ttlEntry',
+    ])
+  })
+})

--- a/packages/sdk/tests/sac-integration.test.ts
+++ b/packages/sdk/tests/sac-integration.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Integration tests for SAC (Stellar Asset Contract) support.
+ *
+ * These tests run against the Soroban testnet and are gated by the
+ * `RUN_INTEGRATION_TESTS=true` environment variable.  They verify that the
+ * SDK can detect and classify archived entries produced by the native XLM SAC
+ * (`CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC` on testnet)
+ * as well as custom fungible-token SAC instances.
+ *
+ * SAC contracts store the following `ContractData` entry types that the SDK
+ * must handle (issue #47):
+ *
+ *   - `Balance`    – per-account token balance
+ *   - `Allowance`  – delegated spend allowance
+ *   - `Admin`      – administrator address
+ *   - `Nonce`      – replay-protection counter
+ *   - `Name` / `Symbol` / `Decimals` – token metadata
+ *
+ * The contract's own instance entry (`ContractInstance`) must also be detected
+ * and prioritised during restoration (issue #48).
+ *
+ * Restoration requirements:
+ *
+ * 1. If a SAC's `ContractInstance` entry is archived, it **must** be restored
+ *    first — before any `ContractData` entries for that contract.  The Soroban
+ *    VM refuses to access `ContractData` belonging to an archived instance.
+ *
+ * 2. SAC `ContractData` entries share the same ledger TTL mechanics as
+ *    ordinary Soroban data entries.  They are restored using the standard
+ *    `RestoreFootprint` operation.
+ *
+ * 3. The SDK surfaces a `sacKeyType` field on each archived key to help
+ *    callers understand which SAC storage slot is affected.
+ */
+import { describe, it, expect } from 'vitest'
+import { SorobanResurrect } from '../src/soroban-resurrect.js'
+import { classifyLedgerKey, classifySacKey } from '../src/footprint-parser.js'
+import { SorobanResurrectError } from '../src/types.js'
+
+const RPC_URL = process.env.SOROBAN_RPC_URL ?? 'https://soroban-testnet.stellar.org'
+const NETWORK_PASSPHRASE =
+  process.env.SOROBAN_NETWORK_PASSPHRASE ?? 'Test SDF Network ; September 2015'
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === 'true'
+
+/**
+ * Well-known testnet SAC contract ID for the native XLM asset.
+ * This contract is deployed on every Soroban testnet reset.
+ */
+const NATIVE_XLM_SAC = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'
+
+const itIf = RUN_INTEGRATION ? it : it.skip
+
+describe('SAC Integration Tests [integration]', () => {
+  const client = new SorobanResurrect({
+    rpcUrl: RPC_URL,
+    networkPassphrase: NETWORK_PASSPHRASE,
+    allowHttp: true,
+  })
+
+  itIf('can query ContractInstance entry for the native XLM SAC', async () => {
+    const { xdr, StrKey } = await import('@stellar/stellar-sdk')
+
+    // Build the LedgerKey for the ContractInstance entry of the native SAC
+    const contractIdBytes = StrKey.decodeContract(NATIVE_XLM_SAC)
+    const instanceKey = xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: xdr.ScAddress.scAddressTypeContract(contractIdBytes),
+        key: xdr.ScVal.scvLedgerKeyContractInstance(),
+        durability: xdr.ContractDataDurability.persistent(),
+      }),
+    )
+
+    const response = await client.getRpcServer().getLedgerEntries(instanceKey)
+
+    // The native SAC's instance entry should always be live on testnet
+    expect(response.entries.length).toBeGreaterThanOrEqual(1)
+
+    // Classify the key and verify it's recognised as contractInstance
+    const classification = classifyLedgerKey(instanceKey)
+    expect(classification.keyType).toBe('contractInstance')
+    expect(classification.restorePriority).toBe(0)
+  })
+
+  itIf('classifies SAC Balance ledger key correctly', async () => {
+    const { xdr, Keypair } = await import('@stellar/stellar-sdk')
+
+    const accountId = Keypair.random().publicKey()
+    const { StrKey } = await import('@stellar/stellar-sdk')
+    const contractIdBytes = StrKey.decodeContract(NATIVE_XLM_SAC)
+
+    const balanceKey = xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: xdr.ScAddress.scAddressTypeContract(contractIdBytes),
+        key: xdr.ScVal.scvVec([
+          xdr.ScVal.scvSymbol('Balance'),
+          xdr.ScVal.scvAddress(
+            xdr.ScAddress.scAddressTypeAccount(
+              xdr.AccountID.publicKeyTypeEd25519(StrKey.decodeEd25519PublicKey(accountId)),
+            ),
+          ),
+        ]),
+        durability: xdr.ContractDataDurability.persistent(),
+      }),
+    )
+
+    const classification = classifyLedgerKey(balanceKey)
+    expect(classification.keyType).toBe('contractData')
+    expect(classification.sacKeyType).toBe('sacBalance')
+    expect(classification.restorePriority).toBe(2)
+  })
+
+  itIf('prioritises ContractInstance before ContractData in restoration order', async () => {
+    // Simulate a mixed archived-key set and verify priority ordering
+    const { xdr, StrKey } = await import('@stellar/stellar-sdk')
+    const contractIdBytes = StrKey.decodeContract(NATIVE_XLM_SAC)
+
+    const instanceKey = xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: xdr.ScAddress.scAddressTypeContract(contractIdBytes),
+        key: xdr.ScVal.scvLedgerKeyContractInstance(),
+        durability: xdr.ContractDataDurability.persistent(),
+      }),
+    )
+
+    const adminKey = xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: xdr.ScAddress.scAddressTypeContract(contractIdBytes),
+        key: xdr.ScVal.scvSymbol('Admin'),
+        durability: xdr.ContractDataDurability.persistent(),
+      }),
+    )
+
+    const instanceClass = classifyLedgerKey(instanceKey)
+    const adminClass = classifyLedgerKey(adminKey)
+
+    expect(instanceClass.restorePriority).toBeLessThan(adminClass.restorePriority)
+  })
+
+  itIf('throws SorobanResurrectError for invalid XDR', async () => {
+    await expect(client.simulate('not-valid-xdr')).rejects.toThrow(SorobanResurrectError)
+  })
+})

--- a/packages/sdk/tests/soroban-resurrect.test.ts
+++ b/packages/sdk/tests/soroban-resurrect.test.ts
@@ -127,6 +127,9 @@ describe('SorobanResurrect', () => {
           contract: () => ({
             contractId: () => Buffer.from('abc123', 'hex'),
           }),
+          // key() must return an ScVal-alike; use a non-SAC symbol (type 15)
+          // so that keyType resolves to 'contractData' (not 'contractInstance')
+          key: () => ({ switch: () => ({ value: 15 }), value: () => Buffer.from('custom') }),
         }),
       } as unknown as xdr.LedgerKey
 


### PR DESCRIPTION
## Description

Closes #47
Closes #48

Adds full support for Stellar Asset Contract (SAC) ledger entries, which use different `ScVal` key structures than ordinary WASM contracts, and properly handles `ContractInstance` entries that must be restored before their dependent data entries.

### Changes

**`src/types.ts`**
- Add `'contractInstance'` to `ArchivedKey.keyType` union (issue #48)
- Add `SacKeyType` union: `'sacBalance' | 'sacAllowance' | 'sacAdmin' | 'sacNonce' | 'sacMetadata'`
- Add `RestorePriority` type (`0–3`) to `ArchivedKey`
- Add `sacKeyType?: SacKeyType` optional field to `ArchivedKey`

**`src/footprint-parser.ts`**
- Add `classifySacKey(dataKey: xdr.ScVal): SacKeyType | undefined` — inspects the raw `ScVal` key of a `ContractData` entry to identify SAC-specific sub-types
- Update `classifyLedgerKey()` to:
  - Detect `ContractInstance` entries (`scvLedgerKeyContractInstance`) and return `keyType: 'contractInstance'` with `restorePriority: 0`
  - Populate `sacKeyType` for SAC `ContractData` entries
  - Return a `restorePriority` on every classification

**`src/soroban-resurrect.ts`**
- Sort `archivedKeys` by `restorePriority` ascending after detection so that `contractInstance` entries (priority 0) are always restored before `contractCode` (1) and `contractData` (2) entries

**`src/index.ts`**
- Export `classifySacKey`, `SacKeyType`, `RestorePriority`

**`tests/sac-contract-data.test.ts`** *(new)*
- 25 unit tests covering every SAC key pattern (`Balance`, `Allowance`, `Admin`, `Nonce`, `Name`, `Symbol`, `Decimals`), `ContractInstance` classification, and priority-ordering logic

**`tests/sac-integration.test.ts`** *(new)*
- Integration tests (gated by `RUN_INTEGRATION_TESTS=true`) that target the native XLM SAC on Soroban testnet

**`README.md`**
- New *Stellar Asset Contract (SAC) Support* section documenting entry types, SAC key table, restoration order, and `classifySacKey` usage

### SAC restoration requirements

1. A SAC's `ContractInstance` entry **must** be restored before any `ContractData` entries for that contract — the Soroban VM refuses to access data belonging to an archived instance.
2. SAC `ContractData` entries are restored with the same `RestoreFootprint` operation as ordinary Soroban data.
3. The `sacKeyType` field lets callers understand which SAC storage slot is archived without parsing raw XDR.

## Type of Change

- [x] New feature
- [x] Documentation update

## Testing

- [x] SDK tests pass (`npm run test -w packages/sdk`) — 54 tests pass
- [x] Build succeeds (`npm run build`)

## Checklist

- [x] My code follows the existing code style
- [x] I have added tests for my changes
- [x] All new and existing tests pass
- [x] README/documentation is updated if needed