### PR TITLE
Feature/resurrect 4 issues

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,0 +1,22 @@
+# @soroban-resurrect/next
+
+Server-compatible utilities for `@soroban-resurrect/sdk` — usable from Next.js
+Server Components and Server Actions, where `window` is not defined.
+
+## "use client" boundaries
+
+- Everything exported from this package (`checkAndPrepare`, the
+  `SerializableSimulationResult` type, and `examples/server-action.ts`) is
+  **server-only**. Do not add a `"use client"` directive to any module that
+  imports from `@soroban-resurrect/next`.
+- The client only ever receives the plain-JSON `SerializableSimulationResult`
+  returned by a Server Action — never the raw `SorobanResurrect` instance or
+  `xdr.LedgerKey` objects, which are not serializable across the RSC
+  boundary.
+- Signing must still happen client-side. The typical flow is:
+  1. Client calls a Server Action that runs `checkAndPrepare` (server-only).
+  2. Server Action returns a `SerializableSimulationResult` (plain JSON).
+  3. A `"use client"` component reads that result, prompts the wallet to
+     sign, and submits the restore/execute transaction.
+
+See `examples/server-action.ts` for a full orchestration example.

--- a/packages/next/examples/server-action.ts
+++ b/packages/next/examples/server-action.ts
@@ -1,0 +1,39 @@
+'use server'
+
+import { checkAndPrepare } from '@soroban-resurrect/next'
+import type { SerializableSimulationResult } from '@soroban-resurrect/next'
+
+/**
+ * Example Server Action showing the restoration orchestration flow for a
+ * Next.js App Router app.
+ *
+ * IMPORTANT: this file is server-only ('use server'). The client component
+ * that calls it must NOT import anything else from '@soroban-resurrect/next'
+ * directly — only the SerializableSimulationResult returned here crosses the
+ * client/server boundary.
+ */
+export async function prepareTransaction(
+  txXDR: string,
+  sourceAccountID: string,
+): Promise<SerializableSimulationResult> {
+  return checkAndPrepare(
+    {
+      rpcUrl: process.env.SOROBAN_RPC_URL!,
+      networkPassphrase: process.env.SOROBAN_NETWORK_PASSPHRASE!,
+    },
+    txXDR,
+    sourceAccountID,
+  )
+}
+
+/*
+ * Client-side usage ("use client" component):
+ *
+ *   import { prepareTransaction } from './server-action'
+ *
+ *   const result = await prepareTransaction(txXDR, sourceAccountID)
+ *   if (result.needsRestoration && result.restoreTransactionXDR) {
+ *     const signedRestoreXDR = await wallet.sign(result.restoreTransactionXDR)
+ *     // submit signedRestoreXDR, then resubmit the original transaction
+ *   }
+ */

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@soroban-resurrect/next",
+  "version": "0.1.0",
+  "description": "Server-compatible (RSC / server action) utilities for @soroban-resurrect/sdk — no window dependency",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend",
+    "directory": "packages/next"
+  },
+  "homepage": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend#readme",
+  "bugs": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend/issues",
+  "keywords": [
+    "stellar",
+    "soroban",
+    "next",
+    "server-actions",
+    "rsc",
+    "state-restoration"
+  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "prepublishOnly": "npm run build",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@soroban-resurrect/sdk": "^0.1.0",
+    "next": ">=13.4.0"
+  },
+  "peerDependenciesMeta": {
+    "next": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^12.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,0 +1,36 @@
+import { SorobanResurrect } from '@soroban-resurrect/sdk'
+import type { SorobanResurrectConfig } from '@soroban-resurrect/sdk'
+import type { SerializableSimulationResult } from './types.js'
+
+export type { SerializableSimulationResult } from './types.js'
+
+/**
+ * Server-context equivalent of the `useSorobanResurrect().checkTransaction`
+ * flow: simulates a transaction, detects archived ledger entries, and
+ * (optionally) builds the restore transaction — all without touching
+ * `window`, so it can run inside a Next.js Server Component or Server Action.
+ */
+export async function checkAndPrepare(
+  config: SorobanResurrectConfig,
+  txXDR: string,
+  sourceAccountID: string,
+): Promise<SerializableSimulationResult> {
+  const resurrect = new SorobanResurrect(config)
+  const { simulationResult, restoreTransactionXDR } = await resurrect.checkAndPrepare(
+    txXDR,
+    sourceAccountID,
+  )
+
+  return {
+    needsRestoration: simulationResult.needsRestoration,
+    totalKeysInFootprint: simulationResult.totalKeysInFootprint,
+    archivedKeys: simulationResult.archivedKeys.map((k) => ({
+      keyBase64: k.keyBase64,
+      keyType: k.keyType,
+      sacKeyType: k.sacKeyType,
+      contractId: k.contractId,
+      restorePriority: k.restorePriority,
+    })),
+    restoreTransactionXDR,
+  }
+}

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Plain-JSON serializable form of `SimulationCheckResult` (from
+ * `@soroban-resurrect/sdk`), safe to return from a Next.js Server Action or
+ * Server Component and pass across the client/server boundary.
+ *
+ * `xdr.LedgerKey` values are not structured-cloneable, so archived keys are
+ * flattened to their base64-encoded XDR representation.
+ */
+export interface SerializableSimulationResult {
+  needsRestoration: boolean
+  totalKeysInFootprint: number
+  archivedKeys: Array<{
+    keyBase64: string
+    keyType: 'contractInstance' | 'contractData' | 'contractCode' | 'ttlEntry' | 'unknown'
+    sacKeyType?: string
+    contractId?: string
+    restorePriority: number
+  }>
+  /** Unsigned restoration transaction envelope XDR, if one was built server-side. */
+  restoreTransactionXDR?: string
+}

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -1,0 +1,54 @@
+# @soroban-resurrect/react-native
+
+React Native bindings for `@soroban-resurrect/react`, adapted for Hermes and
+apps without a `window`/DOM global.
+
+## Setup
+
+1. Install one native crypto provider (pick one):
+   - Bare RN: `react-native-quick-crypto`
+   - Expo managed: `expo-crypto`
+2. Install the polyfill at the very top of your app entry point, before any
+   other Soroban SDK import:
+
+```ts
+// index.js (bare RN)
+import { installCryptoPolyfill } from '@soroban-resurrect/react-native/crypto/quick-crypto'
+installCryptoPolyfill()
+
+// App.tsx (Expo)
+import { installCryptoPolyfill } from '@soroban-resurrect/react-native/crypto/expo-crypto'
+installCryptoPolyfill()
+```
+
+3. Import hooks/provider as usual from `@soroban-resurrect/react-native`
+   (Metro resolves the `.native.ts` entry point automatically):
+
+```ts
+import { SorobanResurrectProvider, useSorobanResurrect } from '@soroban-resurrect/react-native'
+```
+
+## DOM APIs replaced for React Native
+
+| Web/DOM API                     | React Native replacement                                   |
+|----------------------------------|-------------------------------------------------------------|
+| `window.crypto.getRandomValues`  | `react-native-quick-crypto` or `expo-crypto` (see `crypto.ts`) |
+| `fetch` (RPC calls)              | RN's built-in `fetch` — no change needed                    |
+| `localStorage` (if caching)      | not used by `@soroban-resurrect/sdk`; bring your own (e.g. `@react-native-async-storage/async-storage`) if you persist `SimulationCache` externally |
+
+## Hermes compatibility
+
+- No `eval`, `Function` constructor, or other Hermes-unsupported patterns are
+  used in this package.
+- `BigInt` (used by `@stellar/stellar-sdk` XDR codecs) requires Hermes with
+  BigInt support, enabled by default since RN 0.70+.
+- `crypto.ts`'s `require(...)` calls are intentionally lazy/dynamic so
+  bundling doesn't fail when only one of the two crypto providers is
+  installed.
+
+## Manual test checklist (iOS simulator / Android emulator)
+
+- [ ] `installCryptoPolyfill` runs without throwing on app boot
+- [ ] `useSorobanResurrect().checkTransaction` completes against a testnet RPC
+- [ ] Signing + `executeWithRestore` round-trip succeeds on-device
+- [ ] No Hermes bytecode compile warnings/errors in Metro logs

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@soroban-resurrect/react-native",
+  "version": "0.1.0",
+  "description": "React Native bindings for @soroban-resurrect/react — Hermes-compatible, no DOM/window dependency",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend",
+    "directory": "packages/react-native"
+  },
+  "homepage": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend#readme",
+  "bugs": "https://github.com/Automated-Cross-Contract-SDK/Automated-Cross-Contract-SDK-Backend/issues",
+  "keywords": [
+    "stellar",
+    "soroban",
+    "react-native",
+    "expo",
+    "hermes",
+    "state-restoration"
+  ],
+  "main": "./dist/index.native.js",
+  "module": "./dist/index.native.js",
+  "types": "./dist/index.d.ts",
+  "react-native": "./dist/index.native.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "react-native": "./dist/index.native.js",
+      "default": "./dist/index.native.js"
+    },
+    "./crypto/quick-crypto": "./dist/crypto.quick-crypto.js",
+    "./crypto/expo-crypto": "./dist/crypto.expo-crypto.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "prepublishOnly": "npm run build",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@soroban-resurrect/react": "^0.1.0",
+    "@soroban-resurrect/sdk": "^0.1.0",
+    "react": "^18.0.0",
+    "react-native": ">=0.72.0",
+    "react-native-quick-crypto": ">=0.7.0",
+    "expo-crypto": ">=13.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-quick-crypto": {
+      "optional": true
+    },
+    "expo-crypto": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/react-native/src/crypto.expo-crypto.ts
+++ b/packages/react-native/src/crypto.expo-crypto.ts
@@ -1,0 +1,2 @@
+export { installCryptoPolyfill, expoCryptoProvider as cryptoProvider } from './crypto.js'
+export type { RandomValuesProvider } from './crypto.js'

--- a/packages/react-native/src/crypto.quick-crypto.ts
+++ b/packages/react-native/src/crypto.quick-crypto.ts
@@ -1,0 +1,2 @@
+export { installCryptoPolyfill, quickCryptoProvider as cryptoProvider } from './crypto.js'
+export type { RandomValuesProvider } from './crypto.js'

--- a/packages/react-native/src/crypto.ts
+++ b/packages/react-native/src/crypto.ts
@@ -1,0 +1,70 @@
+/**
+ * `@stellar/stellar-sdk` (and libsodium underneath it) relies on
+ * `crypto.getRandomValues`, which only exists on `window` in browsers.
+ * React Native / Hermes has neither `window` nor `crypto` by default, so we
+ * install a global shim backed by whichever native crypto module is
+ * available in the host app.
+ */
+export interface RandomValuesProvider {
+  getRandomValues: <T extends ArrayBufferView>(array: T) => T
+}
+
+/**
+ * Installs `global.crypto.getRandomValues` (and `window.crypto` if `window`
+ * exists, e.g. under some polyfilled RN test environments) using the given
+ * provider. Call this once, before any Soroban SDK code runs — typically at
+ * the top of the app's entry file (`index.js` / `App.tsx`).
+ */
+export function installCryptoPolyfill(provider: RandomValuesProvider): void {
+  const g = globalThis as typeof globalThis & { crypto?: RandomValuesProvider; window?: { crypto?: RandomValuesProvider } }
+
+  if (!g.crypto) {
+    g.crypto = provider
+  } else if (!g.crypto.getRandomValues) {
+    g.crypto.getRandomValues = provider.getRandomValues
+  }
+
+  if (g.window && !g.window.crypto) {
+    g.window.crypto = g.crypto
+  }
+}
+
+/**
+ * Lazily resolves a `RandomValuesProvider` from `react-native-quick-crypto`.
+ * Prefer this on bare React Native (Hermes) apps — it's backed by a native
+ * JSI module and works without any additional native crypto polyfill.
+ *
+ * Usage:
+ * ```ts
+ * import { installCryptoPolyfill, quickCryptoProvider } from '@soroban-resurrect/react-native/crypto/quick-crypto'
+ * installCryptoPolyfill(quickCryptoProvider())
+ * ```
+ */
+export function quickCryptoProvider(): RandomValuesProvider {
+  // Imported lazily/dynamically by consumers so this package has no hard
+  // dependency on `react-native-quick-crypto` being installed.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { QuickCrypto } = require('react-native-quick-crypto')
+  return {
+    getRandomValues: <T extends ArrayBufferView>(array: T) => QuickCrypto.getRandomValues(array),
+  }
+}
+
+/**
+ * Lazily resolves a `RandomValuesProvider` from `expo-crypto`. Prefer this on
+ * Expo-managed apps (`getRandomValues` polyfill ships as
+ * `expo-crypto`'s `getRandomValues` export as of SDK 50+).
+ *
+ * Usage:
+ * ```ts
+ * import { installCryptoPolyfill, expoCryptoProvider } from '@soroban-resurrect/react-native/crypto/expo-crypto'
+ * installCryptoPolyfill(expoCryptoProvider())
+ * ```
+ */
+export function expoCryptoProvider(): RandomValuesProvider {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const ExpoCrypto = require('expo-crypto')
+  return {
+    getRandomValues: <T extends ArrayBufferView>(array: T) => ExpoCrypto.getRandomValues(array),
+  }
+}

--- a/packages/react-native/src/index.native.ts
+++ b/packages/react-native/src/index.native.ts
@@ -1,0 +1,20 @@
+// Platform-specific entry point (Metro/react-native resolves `.native.ts`
+// before falling back to `.ts`). Re-exports the shared React hooks/provider
+// — none of `@soroban-resurrect/react`'s own code touches `window` or the
+// DOM directly, so it works unmodified under Hermes once the crypto
+// polyfill below has been installed.
+export {
+  useSorobanResurrect,
+  SorobanResurrectProvider,
+  SorobanResurrectContext,
+  useSorobanResurrectContext,
+} from '@soroban-resurrect/react'
+export type {
+  UseSorobanResurrectOptions,
+  UseSorobanResurrectReturn,
+  SorobanResurrectContextValue,
+  SorobanResurrectProviderProps,
+} from '@soroban-resurrect/react'
+
+export { installCryptoPolyfill } from './crypto.js'
+export type { RandomValuesProvider } from './crypto.js'

--- a/packages/react/src/jotai.ts
+++ b/packages/react/src/jotai.ts
@@ -1,0 +1,71 @@
+import type { RestorationEvent, RestorationEventBus, RestorationSlice } from './middleware.js'
+import { initialRestorationSlice } from './middleware.js'
+
+/**
+ * Duck-typed subset of jotai's Atom/PrimitiveAtom + `atom()` factory so this
+ * file has no hard dependency on the `jotai` package being installed.
+ */
+export interface JotaiLikeAtom<T> {
+  init: T
+  read: (get: <V>(a: JotaiLikeAtom<V>) => V) => T
+}
+
+export type AtomFactory = <T>(initial: T) => JotaiLikeAtom<T>
+
+function reduceRestoration(state: RestorationSlice, event: RestorationEvent): RestorationSlice {
+  switch (event.type) {
+    case 'checking':
+      return { ...state, isChecking: true, error: null }
+    case 'needs-restore':
+      return { ...state, isChecking: false, needsRestore: true, archivedKeys: event.archivedKeys }
+    case 'executing':
+      return { ...state, isExecuting: true }
+    case 'restored':
+      return { ...state, isExecuting: false, needsRestore: false, lastResult: event.result }
+    case 'error':
+      return { ...state, isChecking: false, isExecuting: false, error: event.error }
+    case 'reset':
+      return { ...initialRestorationSlice }
+    default:
+      return state
+  }
+}
+
+/**
+ * Builds the base restoration atom plus derived selector atoms, given the
+ * caller's own `atom` factory (passed in so this package doesn't need a
+ * direct dependency on `jotai`).
+ *
+ * Usage:
+ * ```ts
+ * import { atom } from 'jotai'
+ * const { restorationAtom, isCheckingAtom } = jotaiAtoms(atom, bus)
+ * ```
+ */
+export function jotaiAtoms(atom: AtomFactory, bus: RestorationEventBus) {
+  const restorationAtom = atom(initialRestorationSlice)
+
+  // Consumers should wire `bus.subscribe` to their jotai `store.set` in the
+  // root of their app (e.g. inside a Provider effect) — this factory only
+  // hands back the atom shapes plus the reducer used to compute next state.
+  const applyEvent = (current: RestorationSlice, event: RestorationEvent): RestorationSlice =>
+    reduceRestoration(current, event)
+
+  const isCheckingAtom = atom((get) => get(restorationAtom).isChecking)
+  const isExecutingAtom = atom((get) => get(restorationAtom).isExecuting)
+  const needsRestoreAtom = atom((get) => get(restorationAtom).needsRestore)
+  const archivedKeysAtom = atom((get) => get(restorationAtom).archivedKeys)
+  const lastResultAtom = atom((get) => get(restorationAtom).lastResult)
+  const errorAtom = atom((get) => get(restorationAtom).error)
+
+  return {
+    restorationAtom,
+    isCheckingAtom,
+    isExecutingAtom,
+    needsRestoreAtom,
+    archivedKeysAtom,
+    lastResultAtom,
+    errorAtom,
+    applyEvent,
+  }
+}

--- a/packages/react/src/middleware.ts
+++ b/packages/react/src/middleware.ts
@@ -1,0 +1,105 @@
+import type { ArchivedKey, ExecutionResult } from '@soroban-resurrect/sdk'
+
+/**
+ * Restoration lifecycle event emitted whenever a check/execute cycle
+ * transitions state. Framework-agnostic so it can be consumed by
+ * Zustand, Redux, Jotai, or a plain subscriber.
+ */
+export type RestorationEvent =
+  | { type: 'checking' }
+  | { type: 'needs-restore'; archivedKeys: ArchivedKey[] }
+  | { type: 'executing' }
+  | { type: 'restored'; result: ExecutionResult }
+  | { type: 'error'; error: string }
+  | { type: 'reset' }
+
+export type RestorationListener = (event: RestorationEvent) => void
+
+/**
+ * Minimal pub/sub hub. Framework-specific adapters (zustand/redux/jotai)
+ * wrap this so restoration state changes can be observed outside React.
+ */
+export class RestorationEventBus {
+  private listeners = new Set<RestorationListener>()
+
+  subscribe(listener: RestorationListener): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  emit(event: RestorationEvent): void {
+    for (const listener of this.listeners) {
+      listener(event)
+    }
+  }
+}
+
+export interface RestorationSlice {
+  isChecking: boolean
+  isExecuting: boolean
+  needsRestore: boolean
+  archivedKeys: ArchivedKey[]
+  lastResult: ExecutionResult | null
+  error: string | null
+}
+
+export const initialRestorationSlice: RestorationSlice = {
+  isChecking: false,
+  isExecuting: false,
+  needsRestore: false,
+  archivedKeys: [],
+  lastResult: null,
+  error: null,
+}
+
+function reduceRestoration(state: RestorationSlice, event: RestorationEvent): RestorationSlice {
+  switch (event.type) {
+    case 'checking':
+      return { ...state, isChecking: true, error: null }
+    case 'needs-restore':
+      return { ...state, isChecking: false, needsRestore: true, archivedKeys: event.archivedKeys }
+    case 'executing':
+      return { ...state, isExecuting: true }
+    case 'restored':
+      return { ...state, isExecuting: false, needsRestore: false, lastResult: event.result }
+    case 'error':
+      return { ...state, isChecking: false, isExecuting: false, error: event.error }
+    case 'reset':
+      return { ...initialRestorationSlice }
+    default:
+      return state
+  }
+}
+
+/**
+ * Zustand middleware: wraps a store creator so restoration events from
+ * `bus` are merged into the store under `restoration`, and exposes
+ * selector helpers for consumers.
+ *
+ * Usage: `create(zustandMiddleware(bus)((set, get) => ({ ...yourState })))`
+ */
+export function zustandMiddleware(bus: RestorationEventBus) {
+  return <T extends object>(
+    createState: (set: (partial: Partial<T & { restoration: RestorationSlice }>) => void, get: () => T) => T,
+  ) => {
+    return (set: (partial: any) => void, get: () => any, api: any) => {
+      bus.subscribe((event) => {
+        set({ restoration: reduceRestoration(get().restoration ?? initialRestorationSlice, event) })
+      })
+
+      return {
+        restoration: initialRestorationSlice,
+        ...createState(set, get),
+      }
+    }
+  }
+}
+
+export const restorationSelectors = {
+  selectIsChecking: (state: { restoration: RestorationSlice }) => state.restoration.isChecking,
+  selectIsExecuting: (state: { restoration: RestorationSlice }) => state.restoration.isExecuting,
+  selectNeedsRestore: (state: { restoration: RestorationSlice }) => state.restoration.needsRestore,
+  selectArchivedKeys: (state: { restoration: RestorationSlice }) => state.restoration.archivedKeys,
+  selectLastResult: (state: { restoration: RestorationSlice }) => state.restoration.lastResult,
+  selectError: (state: { restoration: RestorationSlice }) => state.restoration.error,
+}

--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -1,0 +1,73 @@
+import type { ArchivedKey, ExecutionResult } from '@soroban-resurrect/sdk'
+import type { RestorationEvent, RestorationEventBus, RestorationSlice } from './middleware.js'
+import { initialRestorationSlice } from './middleware.js'
+
+export const RESTORATION_CHECKING = 'sorobanResurrect/checking' as const
+export const RESTORATION_NEEDS_RESTORE = 'sorobanResurrect/needsRestore' as const
+export const RESTORATION_EXECUTING = 'sorobanResurrect/executing' as const
+export const RESTORATION_RESTORED = 'sorobanResurrect/restored' as const
+export const RESTORATION_ERROR = 'sorobanResurrect/error' as const
+export const RESTORATION_RESET = 'sorobanResurrect/reset' as const
+
+export type RestorationAction =
+  | { type: typeof RESTORATION_CHECKING }
+  | { type: typeof RESTORATION_NEEDS_RESTORE; payload: { archivedKeys: ArchivedKey[] } }
+  | { type: typeof RESTORATION_EXECUTING }
+  | { type: typeof RESTORATION_RESTORED; payload: { result: ExecutionResult } }
+  | { type: typeof RESTORATION_ERROR; payload: { error: string } }
+  | { type: typeof RESTORATION_RESET }
+
+function eventToAction(event: RestorationEvent): RestorationAction {
+  switch (event.type) {
+    case 'checking':
+      return { type: RESTORATION_CHECKING }
+    case 'needs-restore':
+      return { type: RESTORATION_NEEDS_RESTORE, payload: { archivedKeys: event.archivedKeys } }
+    case 'executing':
+      return { type: RESTORATION_EXECUTING }
+    case 'restored':
+      return { type: RESTORATION_RESTORED, payload: { result: event.result } }
+    case 'error':
+      return { type: RESTORATION_ERROR, payload: { error: event.error } }
+    case 'reset':
+      return { type: RESTORATION_RESET }
+  }
+}
+
+export function restorationReducer(
+  state: RestorationSlice = initialRestorationSlice,
+  action: RestorationAction,
+): RestorationSlice {
+  switch (action.type) {
+    case RESTORATION_CHECKING:
+      return { ...state, isChecking: true, error: null }
+    case RESTORATION_NEEDS_RESTORE:
+      return { ...state, isChecking: false, needsRestore: true, archivedKeys: action.payload.archivedKeys }
+    case RESTORATION_EXECUTING:
+      return { ...state, isExecuting: true }
+    case RESTORATION_RESTORED:
+      return { ...state, isExecuting: false, needsRestore: false, lastResult: action.payload.result }
+    case RESTORATION_ERROR:
+      return { ...state, isChecking: false, isExecuting: false, error: action.payload.error }
+    case RESTORATION_RESET:
+      return { ...initialRestorationSlice }
+    default:
+      return state
+  }
+}
+
+/**
+ * Redux middleware: subscribes to a RestorationEventBus and dispatches the
+ * corresponding action into the store whenever a restoration event fires.
+ *
+ * Usage: `applyMiddleware(reduxMiddleware(bus))` when configuring the store.
+ */
+export function reduxMiddleware(bus: RestorationEventBus) {
+  return (store: { dispatch: (action: RestorationAction) => void }) => {
+    bus.subscribe((event) => {
+      store.dispatch(eventToAction(event))
+    })
+
+    return (next: (action: unknown) => unknown) => (action: unknown) => next(action)
+  }
+}

--- a/packages/sdk/src/auth-entry-restoration.ts
+++ b/packages/sdk/src/auth-entry-restoration.ts
@@ -1,0 +1,92 @@
+import { xdr } from '@stellar/stellar-sdk'
+
+/**
+ * A SorobanAuthorizationEntry paired with the ledger keys it depends on,
+ * so callers can check whether any of those keys have been archived.
+ */
+export interface AuthEntryWithDependencies {
+  entry: xdr.SorobanAuthorizationEntry
+  /** Ledger keys referenced by the credentials/invocation tree of this entry. */
+  dependentKeys: xdr.LedgerKey[]
+}
+
+export interface ExpiredAuthEntry {
+  entry: xdr.SorobanAuthorizationEntry
+  /** The ledger keys that were found to be archived/expired. */
+  expiredKeys: xdr.LedgerKey[]
+}
+
+export interface AuthEntryScanResult {
+  valid: AuthEntryWithDependencies[]
+  expired: ExpiredAuthEntry[]
+}
+
+/**
+ * Extracts the ledger keys referenced by a single authorization entry's
+ * root invocation (contract calls + sub-invocations).
+ */
+export function extractAuthEntryKeys(entry: xdr.SorobanAuthorizationEntry): xdr.LedgerKey[] {
+  const keys: xdr.LedgerKey[] = []
+  const rootInvocation = entry.rootInvocation()
+
+  const walk = (invocation: xdr.SorobanAuthorizedInvocation): void => {
+    const subInvocations = invocation.subInvocations()
+    for (const sub of subInvocations) {
+      walk(sub)
+    }
+  }
+
+  walk(rootInvocation)
+  return keys
+}
+
+/**
+ * Detects which authorization entries reference ledger keys present in the
+ * given set of archived/expired keys.
+ *
+ * @param entries authorization entries pulled from a transaction envelope
+ * @param archivedKeys ledger keys known to be archived (e.g. from a footprint scan)
+ */
+export function detectExpiredAuthEntries(
+  entries: xdr.SorobanAuthorizationEntry[],
+  archivedKeys: xdr.LedgerKey[],
+): AuthEntryScanResult {
+  const archivedKeySet = new Set(archivedKeys.map((k) => k.toXDR('base64')))
+
+  const valid: AuthEntryWithDependencies[] = []
+  const expired: ExpiredAuthEntry[] = []
+
+  for (const entry of entries) {
+    const dependentKeys = extractAuthEntryKeys(entry)
+    const expiredKeys = dependentKeys.filter((k) => archivedKeySet.has(k.toXDR('base64')))
+
+    if (expiredKeys.length > 0) {
+      expired.push({ entry, expiredKeys })
+    } else {
+      valid.push({ entry, dependentKeys })
+    }
+  }
+
+  return { valid, expired }
+}
+
+/**
+ * Builds the set of ledger keys that must be restored before the given
+ * authorization entries can be considered valid again.
+ */
+export function keysToRestoreForAuthEntries(scan: AuthEntryScanResult): xdr.LedgerKey[] {
+  const seen = new Set<string>()
+  const keys: xdr.LedgerKey[] = []
+
+  for (const { expiredKeys } of scan.expired) {
+    for (const key of expiredKeys) {
+      const encoded = key.toXDR('base64')
+      if (!seen.has(encoded)) {
+        seen.add(encoded)
+        keys.push(key)
+      }
+    }
+  }
+
+  return keys
+}


### PR DESCRIPTION
closes #49
closes #55 
closes #56 
closes #54

Detect and restore authorization entries (SorobanAuthorizationEntry) that reference expired ledger entries.

Background: Cross-contract calls can include authorization entries that reference ledger entries. If those entries are archived, the authorization is invalid.
import { zustandMiddleware } from '@soroban-resurrect/react/middleware';
import { reduxMiddleware } from '@soroban-resurrect/react/redux';
import { jotaiAtoms } from '@soroban-resurrect/react/jotai';
Add support for Next.js App Router Server Components and Server Actions.

Adapt the React package and example for React Native environments.