### PR TITLE
feat(react): wallet adapters, custom signing, generic hook, tx history

### DIFF
--- a/packages/react/src/SorobanResurrectProvider.tsx
+++ b/packages/react/src/SorobanResurrectProvider.tsx
@@ -3,16 +3,17 @@
 import { type ReactNode, useMemo } from 'react'
 import { SorobanResurrectContext } from './SorobanResurrectContext.js'
 import { useSorobanResurrect } from './useSorobanResurrect.js'
-import type { UseSorobanResurrectOptions } from './types.js'
+import type { UseSorobanResurrectOptions, SigningStrategy } from './types.js'
 
-export interface SorobanResurrectProviderProps extends UseSorobanResurrectOptions {
+export interface SorobanResurrectProviderProps<TSigner extends SigningStrategy = SigningStrategy>
+  extends UseSorobanResurrectOptions<TSigner> {
   children: ReactNode
 }
 
-export function SorobanResurrectProvider({
+export function SorobanResurrectProvider<TSigner extends SigningStrategy = SigningStrategy>({
   children,
   ...options
-}: SorobanResurrectProviderProps) {
+}: SorobanResurrectProviderProps<TSigner>) {
   const resurrect = useSorobanResurrect(options)
 
   const config = useMemo(

--- a/packages/react/src/adapters.ts
+++ b/packages/react/src/adapters.ts
@@ -1,0 +1,221 @@
+import type { SorobanWalletAdapter, SignOptions } from './types.js'
+
+function getGlobal<T = any>(key: string): T | undefined {
+  return typeof globalThis !== 'undefined' ? (globalThis as any)[key] : undefined
+}
+
+/** https://docs.freighter.app */
+export class FreighterAdapter implements SorobanWalletAdapter {
+  readonly id = 'freighter'
+  readonly name = 'Freighter'
+  readonly icon?: string
+
+  isSupported(): boolean {
+    return !!getGlobal('freighterApi')
+  }
+
+  isConnected(): boolean {
+    return !!getGlobal('freighterApi')
+  }
+
+  async connect(): Promise<string> {
+    const api = getGlobal<any>('freighterApi')
+    if (!api) throw new Error('Freighter extension not found')
+    await api.requestAccess?.()
+    const { address } = await api.getAddress()
+    return address
+  }
+
+  async disconnect(): Promise<void> {
+    // Freighter has no explicit disconnect API; access is revoked from the extension.
+  }
+
+  async getNetwork(): Promise<{ networkPassphrase: string; networkUrl?: string }> {
+    const api = getGlobal<any>('freighterApi')
+    if (!api) throw new Error('Freighter extension not found')
+    const details = await api.getNetworkDetails()
+    return { networkPassphrase: details.networkPassphrase, networkUrl: details.networkUrl }
+  }
+
+  async signTransaction(xdr: string, opts?: SignOptions): Promise<string> {
+    const api = getGlobal<any>('freighterApi')
+    if (!api) throw new Error('Freighter extension not found')
+    const { signedTxXdr } = await api.signTransaction(xdr, {
+      networkPassphrase: opts?.networkPassphrase,
+      address: opts?.address,
+    })
+    return signedTxXdr
+  }
+}
+
+/** https://albedo.link/docs */
+export class AlbedoAdapter implements SorobanWalletAdapter {
+  readonly id = 'albedo'
+  readonly name = 'Albedo'
+  readonly icon?: string
+  #publicKey: string | undefined
+
+  isSupported(): boolean {
+    return !!getGlobal('albedo')
+  }
+
+  isConnected(): boolean {
+    return !!this.#publicKey
+  }
+
+  async connect(): Promise<string> {
+    const albedo = getGlobal<any>('albedo')
+    if (!albedo) throw new Error('Albedo is not available')
+    const { pubkey } = await albedo.publicKey({})
+    this.#publicKey = pubkey
+    return pubkey
+  }
+
+  async disconnect(): Promise<void> {
+    this.#publicKey = undefined
+  }
+
+  async getNetwork(): Promise<{ networkPassphrase: string; networkUrl?: string }> {
+    throw new Error('Albedo does not expose network details; pass networkPassphrase explicitly')
+  }
+
+  async signTransaction(xdr: string, opts?: SignOptions): Promise<string> {
+    const albedo = getGlobal<any>('albedo')
+    if (!albedo) throw new Error('Albedo is not available')
+    const { signed_envelope_xdr: signedXdr } = await albedo.tx({
+      xdr,
+      pubkey: opts?.address ?? this.#publicKey,
+      network: opts?.networkPassphrase,
+    })
+    return signedXdr
+  }
+}
+
+/** https://docs.rabet.io */
+export class RabetAdapter implements SorobanWalletAdapter {
+  readonly id = 'rabet'
+  readonly name = 'Rabet'
+  readonly icon?: string
+  #publicKey: string | undefined
+
+  isSupported(): boolean {
+    return !!getGlobal('rabet')
+  }
+
+  isConnected(): boolean {
+    return !!this.#publicKey
+  }
+
+  async connect(): Promise<string> {
+    const rabet = getGlobal<any>('rabet')
+    if (!rabet) throw new Error('Rabet extension not found')
+    const { publicKey } = await rabet.connect()
+    this.#publicKey = publicKey
+    return publicKey
+  }
+
+  async disconnect(): Promise<void> {
+    const rabet = getGlobal<any>('rabet')
+    await rabet?.disconnect?.()
+    this.#publicKey = undefined
+  }
+
+  async getNetwork(): Promise<{ networkPassphrase: string; networkUrl?: string }> {
+    const rabet = getGlobal<any>('rabet')
+    if (!rabet) throw new Error('Rabet extension not found')
+    const { network, networkPassphrase, networkUrl } = await rabet.getNetwork()
+    return { networkPassphrase: networkPassphrase ?? network, networkUrl }
+  }
+
+  async signTransaction(xdr: string, opts?: SignOptions): Promise<string> {
+    const rabet = getGlobal<any>('rabet')
+    if (!rabet) throw new Error('Rabet extension not found')
+    const { xdr: signedXdr } = await rabet.sign(xdr, opts?.networkPassphrase)
+    return signedXdr
+  }
+}
+
+/** https://docs.xbull.app */
+export class XBullAdapter implements SorobanWalletAdapter {
+  readonly id = 'xbull'
+  readonly name = 'xBull'
+  readonly icon?: string
+  #publicKey: string | undefined
+
+  isSupported(): boolean {
+    return !!getGlobal('xBullSDK')
+  }
+
+  isConnected(): boolean {
+    return !!this.#publicKey
+  }
+
+  async connect(): Promise<string> {
+    const xBull = getGlobal<any>('xBullSDK')
+    if (!xBull) throw new Error('xBull extension not found')
+    const [publicKey] = await xBull.connect({ canRequestPublicKey: true, canRequestSign: true })
+    this.#publicKey = publicKey
+    return publicKey
+  }
+
+  async disconnect(): Promise<void> {
+    const xBull = getGlobal<any>('xBullSDK')
+    await xBull?.disconnect?.()
+    this.#publicKey = undefined
+  }
+
+  async getNetwork(): Promise<{ networkPassphrase: string; networkUrl?: string }> {
+    const xBull = getGlobal<any>('xBullSDK')
+    if (!xBull) throw new Error('xBull extension not found')
+    const { network, networkPassphrase, networkUrl } = await xBull.getNetwork()
+    return { networkPassphrase: networkPassphrase ?? network, networkUrl }
+  }
+
+  async signTransaction(xdr: string, opts?: SignOptions): Promise<string> {
+    const xBull = getGlobal<any>('xBullSDK')
+    if (!xBull) throw new Error('xBull extension not found')
+    return xBull.sign({
+      xdr,
+      publicKeys: this.#publicKey ? [this.#publicKey] : undefined,
+      network: opts?.networkPassphrase,
+    })
+  }
+}
+
+/** https://github.com/Lobstrco/lobstr-signer-extension */
+export class LobstrAdapter implements SorobanWalletAdapter {
+  readonly id = 'lobstr'
+  readonly name = 'LOBSTR'
+  readonly icon?: string
+  #publicKey: string | undefined
+
+  isSupported(): boolean {
+    return !!getGlobal('lobstrApi')
+  }
+
+  isConnected(): boolean {
+    return !!this.#publicKey
+  }
+
+  async connect(): Promise<string> {
+    const lobstr = getGlobal<any>('lobstrApi')
+    if (!lobstr) throw new Error('LOBSTR signer extension not found')
+    const publicKey = await lobstr.connect()
+    this.#publicKey = publicKey
+    return publicKey
+  }
+
+  async disconnect(): Promise<void> {
+    this.#publicKey = undefined
+  }
+
+  async getNetwork(): Promise<{ networkPassphrase: string; networkUrl?: string }> {
+    throw new Error('LOBSTR does not expose network details; pass networkPassphrase explicitly')
+  }
+
+  async signTransaction(xdr: string, opts?: SignOptions): Promise<string> {
+    const lobstr = getGlobal<any>('lobstrApi')
+    if (!lobstr) throw new Error('LOBSTR signer extension not found')
+    return lobstr.signTransaction(xdr, { networkPassphrase: opts?.networkPassphrase })
+  }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,10 +1,21 @@
 export { useSorobanResurrect } from './useSorobanResurrect.js'
 export { SorobanResurrectProvider } from './SorobanResurrectProvider.js'
 export { SorobanResurrectContext, useSorobanResurrectContext } from './SorobanResurrectContext.js'
+export {
+  FreighterAdapter,
+  AlbedoAdapter,
+  RabetAdapter,
+  XBullAdapter,
+  LobstrAdapter,
+} from './adapters.js'
 export type {
   UseSorobanResurrectOptions,
   UseSorobanResurrectReturn,
   SorobanResurrectContextValue,
+  SorobanWalletAdapter,
+  SigningStrategy,
+  SignOptions,
+  TransactionRecord,
 } from './types.js'
 export type { SorobanResurrectProviderProps } from './SorobanResurrectProvider.js'
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,6 +1,44 @@
 import type { SorobanResurrectConfig, ArchivedKey, ExecutionResult, PreFlightConfig } from '@soroban-resurrect/sdk'
 
-export interface UseSorobanResurrectOptions {
+export interface SignOptions {
+  networkPassphrase?: string
+  address?: string
+}
+
+/**
+ * Wallet-agnostic signer interface. Built-in implementations live in ./adapters.js
+ * (FreighterAdapter, AlbedoAdapter, RabetAdapter, XBullAdapter, LobstrAdapter).
+ */
+export interface SorobanWalletAdapter {
+  id: string
+  name: string
+  icon?: string
+  isConnected(): boolean
+  connect(): Promise<string>
+  disconnect(): Promise<void>
+  getNetwork(): Promise<{ networkPassphrase: string; networkUrl?: string }>
+  signTransaction(xdr: string, opts?: SignOptions): Promise<string>
+  isSupported(): boolean
+}
+
+/**
+ * A signing strategy is either a full wallet adapter or a bare signing function,
+ * so callers can inject multi-sig / hardware-wallet / custom key management flows.
+ */
+export type SigningStrategy = SorobanWalletAdapter | ((xdr: string, opts?: SignOptions) => Promise<string>)
+
+export interface TransactionRecord {
+  id: string
+  originalTxHash?: string
+  restoreTxHash?: string
+  archivedKeys: ArchivedKey[]
+  status: 'success' | 'failed'
+  error?: string
+  timestamp: number
+  durationMs: number
+}
+
+export interface UseSorobanResurrectOptions<TSigner extends SigningStrategy = SigningStrategy> {
   rpcUrl: string
   networkPassphrase: string
   allowHttp?: boolean
@@ -11,12 +49,22 @@ export interface UseSorobanResurrectOptions {
   timeout?: number
   preFlight?: PreFlightConfig
   onError?: (error: Error) => void
+  /**
+   * Wallet adapter or signing function used as the default signer when
+   * `executeWithRestore` is called without an explicit `signTransaction` argument.
+   */
+  signingStrategy?: TSigner
+  /**
+   * Persist transaction history to localStorage under this key.
+   * Pass `true` to use the default key, a string for a custom key, or omit/false to disable.
+   */
+  persistHistory?: boolean | string
 }
 
-export interface UseSorobanResurrectReturn {
+export interface UseSorobanResurrectReturn<TSigner extends SigningStrategy = SigningStrategy> {
   executeWithRestore: (
     txXDR: string,
-    signTransaction: (xdr: string) => Promise<string>,
+    signTransaction?: (xdr: string) => Promise<string>,
     options?: { forceRefresh?: boolean },
   ) => Promise<ExecutionResult>
   checkTransaction: (
@@ -33,6 +81,10 @@ export interface UseSorobanResurrectReturn {
   needsRestore: boolean
   archivedKeys: ArchivedKey[]
   reset: () => void
+  /** The signing strategy passed via options, typed as-is for adapter-specific member access (e.g. `.disconnect()`). */
+  signer: TSigner | undefined
+  history: TransactionRecord[]
+  clearHistory: () => void
 }
 
 export interface SorobanResurrectContextValue {

--- a/packages/react/src/useSorobanResurrect.ts
+++ b/packages/react/src/useSorobanResurrect.ts
@@ -4,7 +4,45 @@ import { useState, useCallback, useRef, useMemo } from 'react'
 import { TransactionBuilder, Transaction } from '@stellar/stellar-sdk'
 import { SorobanResurrect, SorobanResurrectError } from '@soroban-resurrect/sdk'
 import type { SorobanResurrectConfig, ExecutionResult, ArchivedKey } from '@soroban-resurrect/sdk'
-import type { UseSorobanResurrectOptions, UseSorobanResurrectReturn } from './types.js'
+import type {
+  UseSorobanResurrectOptions,
+  UseSorobanResurrectReturn,
+  SigningStrategy,
+  TransactionRecord,
+} from './types.js'
+
+const DEFAULT_HISTORY_STORAGE_KEY = 'soroban-resurrect:history'
+
+function resolveSigner(strategy: SigningStrategy | undefined): ((xdr: string) => Promise<string>) | undefined {
+  if (!strategy) return undefined
+  if (typeof strategy === 'function') return (xdr: string) => strategy(xdr)
+  return (xdr: string) => strategy.signTransaction(xdr)
+}
+
+function generateId(): string {
+  const cryptoObj = typeof globalThis !== 'undefined' ? (globalThis as any).crypto : undefined
+  if (cryptoObj?.randomUUID) return cryptoObj.randomUUID()
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}`
+}
+
+function loadHistory(storageKey: string | undefined): TransactionRecord[] {
+  if (!storageKey || typeof window === 'undefined' || !window.localStorage) return []
+  try {
+    const raw = window.localStorage.getItem(storageKey)
+    return raw ? (JSON.parse(raw) as TransactionRecord[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveHistory(storageKey: string | undefined, history: TransactionRecord[]): void {
+  if (!storageKey || typeof window === 'undefined' || !window.localStorage) return
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(history))
+  } catch {
+    // Ignore storage failures (quota exceeded, private browsing, etc.)
+  }
+}
 
 function parseSource(txXDR: string, networkPassphrase: string): string {
   try {
@@ -52,7 +90,9 @@ async function hashTxXDR(txXDR: string): Promise<string> {
   return (hash >>> 0).toString(16).padStart(8, '0')
 }
 
-export function useSorobanResurrect(options: UseSorobanResurrectOptions): UseSorobanResurrectReturn {
+export function useSorobanResurrect<TSigner extends SigningStrategy = SigningStrategy>(
+  options: UseSorobanResurrectOptions<TSigner>,
+): UseSorobanResurrectReturn<TSigner> {
   const clientRef = useRef<SorobanResurrect | null>(null)
   const simulationCacheRef = useRef<Map<string, SimulationCacheEntry>>(new Map())
 
@@ -62,6 +102,24 @@ export function useSorobanResurrect(options: UseSorobanResurrectOptions): UseSor
   const [error, setError] = useState<string | null>(null)
   const [needsRestore, setNeedsRestore] = useState(false)
   const [archivedKeys, setArchivedKeys] = useState<ArchivedKey[]>([])
+
+  const historyStorageKey = options.persistHistory
+    ? (typeof options.persistHistory === 'string' ? options.persistHistory : DEFAULT_HISTORY_STORAGE_KEY)
+    : undefined
+  const [history, setHistory] = useState<TransactionRecord[]>(() => loadHistory(historyStorageKey))
+
+  const addHistoryRecord = useCallback((record: TransactionRecord) => {
+    setHistory((prev) => {
+      const next = [...prev, record]
+      saveHistory(historyStorageKey, next)
+      return next
+    })
+  }, [historyStorageKey])
+
+  const clearHistory = useCallback(() => {
+    setHistory([])
+    saveHistory(historyStorageKey, [])
+  }, [historyStorageKey])
 
   // Stabilize onLog so it doesn't trigger config re-memoization when options change
   const preFlightEnabled = options.preFlight?.enabled ?? true
@@ -159,9 +217,17 @@ export function useSorobanResurrect(options: UseSorobanResurrectOptions): UseSor
 
   const executeWithRestore = useCallback(async (
     txXDR: string,
-    signTransaction: (xdr: string) => Promise<string>,
+    signTransaction?: (xdr: string) => Promise<string>,
     { forceRefresh = false }: { forceRefresh?: boolean } = {},
   ): Promise<ExecutionResult> => {
+    const sign = signTransaction ?? resolveSigner(options.signingStrategy)
+    if (!sign) {
+      throw new Error(
+        'executeWithRestore requires a signTransaction argument or a signingStrategy option',
+      )
+    }
+
+    const startedAt = Date.now()
     setIsExecuting(true)
     setError(null)
     try {
@@ -170,7 +236,7 @@ export function useSorobanResurrect(options: UseSorobanResurrectOptions): UseSor
       const simulation = await getCachedSimulation(txXDR, forceRefresh)
 
       if (!simulation.needsRestoration) {
-        const signedXDR = await signTransaction(txXDR)
+        const signedXDR = await sign(txXDR)
         const hash = computeHash(signedXDR, options.networkPassphrase)
         const result: ExecutionResult = {
           success: true,
@@ -179,6 +245,14 @@ export function useSorobanResurrect(options: UseSorobanResurrectOptions): UseSor
         }
         setLastResult(result)
         options.preFlight?.onRestoreComplete?.(result)
+        addHistoryRecord({
+          id: generateId(),
+          originalTxHash: result.originalTxHash,
+          archivedKeys: [],
+          status: 'success',
+          timestamp: startedAt,
+          durationMs: Date.now() - startedAt,
+        })
         return result
       }
 
@@ -196,13 +270,23 @@ export function useSorobanResurrect(options: UseSorobanResurrectOptions): UseSor
         restoreTx.transactionXDR,
         txXDR,
         async (xdr: string) => {
-          const signed = await signTransaction(xdr)
+          const signed = await sign(xdr)
           return signed
         },
       )
 
       setLastResult(result)
       options.preFlight?.onRestoreComplete?.(result)
+      addHistoryRecord({
+        id: generateId(),
+        originalTxHash: result.originalTxHash,
+        restoreTxHash: result.restoreTxHash,
+        archivedKeys: simulation.archivedKeys,
+        status: result.success ? 'success' : 'failed',
+        error: result.error,
+        timestamp: startedAt,
+        durationMs: Date.now() - startedAt,
+      })
       return result
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -210,12 +294,20 @@ export function useSorobanResurrect(options: UseSorobanResurrectOptions): UseSor
       const error = err instanceof Error ? err : new Error(message)
       options.onError?.(error)
       options.preFlight?.onError?.(error)
+      addHistoryRecord({
+        id: generateId(),
+        archivedKeys,
+        status: 'failed',
+        error: message,
+        timestamp: startedAt,
+        durationMs: Date.now() - startedAt,
+      })
       if (err instanceof SorobanResurrectError) throw err
       throw new SorobanResurrectError(message, 'ORIGINAL_TX_FAILED', err)
     } finally {
       setIsExecuting(false)
     }
-  }, [getClient, options])
+  }, [getClient, options, addHistoryRecord, archivedKeys])
 
   const reset = useCallback(() => {
     setIsChecking(false)
@@ -236,5 +328,8 @@ export function useSorobanResurrect(options: UseSorobanResurrectOptions): UseSor
     needsRestore,
     archivedKeys,
     reset,
+    signer: options.signingStrategy,
+    history,
+    clearHistory,
   }
 }


### PR DESCRIPTION
## Summary
- Adds a wallet-agnostic `SorobanWalletAdapter` interface with built-in `FreighterAdapter`, `AlbedoAdapter`, `RabetAdapter`, `XBullAdapter`, and `LobstrAdapter` implementations.
- Adds a `signingStrategy` option (adapter instance or plain signing function) that `SorobanResurrectProvider`/`useSorobanResurrect` use as the default signer for `executeWithRestore`, enabling multi-sig, hardware wallet, or other custom signing flows.
- Makes `useSorobanResurrect` (and its options/return types) generic over the signer type so adapter-specific methods (e.g. `.disconnect()`) are type-safe when a concrete adapter type is used.
- Adds `TransactionRecord` history tracking: `executeWithRestore` calls are recorded with status/duration/hashes and exposed as `history` / `clearHistory`, optionally persisted to `localStorage` via `persistHistory`.

Closes #61, closes #62, closes #63, closes #64

## Test plan
- [x] `tsc --noEmit` on the changed/new `packages/react/src` files (verified clean against the package's existing type surface)
- [ ] Test suite intentionally skipped per request
