### PR TITLE
feat(sdk): add wallet adapters for xBull, Lobstr, WalletConnect v2, Ledger

### DIFF
--- a/docs/wallet_adapters.md
+++ b/docs/wallet_adapters.md
@@ -1,0 +1,3 @@
+# Wallet Adapters
+
+Adds a `SorobanWalletAdapter` interface and four implementations — `XBullAdapter`, `LobstrAdapter`, `WalletConnectAdapter`, and `LedgerAdapter` — so callers can connect wallets and sign Soroban transactions without depending on any single wallet's SDK directly. Wallet SDKs (`@xbull/wallet-connect`, `lobstr-wallet-sdk`, `@walletconnect/web3wallet`, `@ledgerhq/hw-app-str`, ...) are optional peer dependencies, lazily imported only when the corresponding adapter is used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5636,6 +5636,42 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@ledgerhq/hw-app-str": "^6.29.0",
+        "@ledgerhq/hw-transport-webhid": "^6.29.0",
+        "@ledgerhq/hw-transport-webusb": "^6.29.0",
+        "@walletconnect/core": "^2.11.0",
+        "@walletconnect/modal": "^2.6.0",
+        "@walletconnect/web3wallet": "^1.11.0",
+        "@xbull/wallet-connect": "^1.0.0",
+        "lobstr-wallet-sdk": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ledgerhq/hw-app-str": {
+          "optional": true
+        },
+        "@ledgerhq/hw-transport-webhid": {
+          "optional": true
+        },
+        "@ledgerhq/hw-transport-webusb": {
+          "optional": true
+        },
+        "@walletconnect/core": {
+          "optional": true
+        },
+        "@walletconnect/modal": {
+          "optional": true
+        },
+        "@walletconnect/web3wallet": {
+          "optional": true
+        },
+        "@xbull/wallet-connect": {
+          "optional": true
+        },
+        "lobstr-wallet-sdk": {
+          "optional": true
+        }
       }
     }
   }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -52,6 +52,26 @@
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0"
   },
+  "peerDependencies": {
+    "@xbull/wallet-connect": "^1.0.0",
+    "lobstr-wallet-sdk": "^1.0.0",
+    "@walletconnect/core": "^2.11.0",
+    "@walletconnect/web3wallet": "^1.11.0",
+    "@walletconnect/modal": "^2.6.0",
+    "@ledgerhq/hw-app-str": "^6.29.0",
+    "@ledgerhq/hw-transport-webhid": "^6.29.0",
+    "@ledgerhq/hw-transport-webusb": "^6.29.0"
+  },
+  "peerDependenciesMeta": {
+    "@xbull/wallet-connect": { "optional": true },
+    "lobstr-wallet-sdk": { "optional": true },
+    "@walletconnect/core": { "optional": true },
+    "@walletconnect/web3wallet": { "optional": true },
+    "@walletconnect/modal": { "optional": true },
+    "@ledgerhq/hw-app-str": { "optional": true },
+    "@ledgerhq/hw-transport-webhid": { "optional": true },
+    "@ledgerhq/hw-transport-webusb": { "optional": true }
+  },
   "devDependencies": {
     "@vitest/coverage-v8": "^2.0.0",
     "tsup": "^8.3.0",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -45,3 +45,20 @@ export { VERSION } from './version.js'
 
 export { RpcFailoverManager } from './rpc-failover.js'
 export type { RpcEndpointHealth, RpcFailoverConfig } from './rpc-failover.js'
+
+export { WalletAdapterError, loadOptionalWalletDependency, bytesToBase64 } from './wallet-adapter.js'
+export type { SorobanWalletAdapter, SignTransactionOptions, WalletConnectionResult, WalletAdapterErrorCode } from './wallet-adapter.js'
+
+export { XBullAdapter } from './xbull-adapter.js'
+export { LobstrAdapter } from './lobstr-adapter.js'
+export {
+  WalletConnectAdapter,
+  STELLAR_CAIP2_NAMESPACE,
+  STELLAR_MAINNET_CHAIN_ID,
+  STELLAR_TESTNET_CHAIN_ID,
+  SOROBAN_WC_METHODS,
+  SOROBAN_WC_EVENTS,
+} from './walletconnect-adapter.js'
+export type { WalletConnectAdapterConfig, WalletMetadata } from './walletconnect-adapter.js'
+export { LedgerAdapter } from './ledger-adapter.js'
+export type { LedgerAdapterConfig } from './ledger-adapter.js'

--- a/packages/sdk/src/ledger-adapter.ts
+++ b/packages/sdk/src/ledger-adapter.ts
@@ -1,0 +1,152 @@
+/**
+ * Ledger Hardware Wallet Adapter
+ *
+ * Integrates Ledger devices running the Stellar app via `@ledgerhq/hw-app-str`,
+ * connecting over WebHID (falling back to WebUSB when unavailable). The
+ * transaction's signature base is streamed to the device in APDU chunks by
+ * hw-app-str, which the user reviews and approves on the device screen.
+ */
+
+import { TransactionBuilder } from '@stellar/stellar-sdk'
+import type { SorobanWalletAdapter, SignTransactionOptions, WalletConnectionResult } from './wallet-adapter.js'
+import { WalletAdapterError, loadOptionalWalletDependency, bytesToBase64 } from './wallet-adapter.js'
+
+const APP_MODULE_NAME = '@ledgerhq/hw-app-str'
+const WEBHID_MODULE_NAME = '@ledgerhq/hw-transport-webhid'
+const WEBUSB_MODULE_NAME = '@ledgerhq/hw-transport-webusb'
+
+const DEFAULT_DERIVATION_PATH = "44'/148'/0'"
+
+interface LedgerTransport {
+  close(): Promise<void>
+  on(event: 'disconnect', handler: (error: unknown) => void): void
+}
+
+interface StrApp {
+  getPublicKey(path: string): Promise<{ publicKey: string }>
+  signTransaction(path: string, signatureBase: Uint8Array): Promise<{ signature: Uint8Array }>
+}
+
+export interface LedgerAdapterConfig {
+  /** BIP-44 derivation path for the Stellar app. Defaults to "44'/148'/0'". */
+  derivationPath?: string
+}
+
+export class LedgerAdapter implements SorobanWalletAdapter {
+  readonly id = 'ledger'
+  readonly name = 'Ledger'
+
+  private readonly derivationPath: string
+  private transport: LedgerTransport | null = null
+  private app: StrApp | null = null
+  private publicKey: string | null = null
+  private deviceDisconnected = false
+
+  constructor(config: LedgerAdapterConfig = {}) {
+    this.derivationPath = config.derivationPath ?? DEFAULT_DERIVATION_PATH
+  }
+
+  async isAvailable(): Promise<boolean> {
+    if (typeof navigator === 'undefined') return false
+    const nav = navigator as unknown as { hid?: unknown; usb?: unknown }
+    return Boolean(nav.hid || nav.usb)
+  }
+
+  async connect(): Promise<WalletConnectionResult> {
+    const app = await this.getApp()
+    try {
+      const { publicKey } = await app.getPublicKey(this.derivationPath)
+      this.publicKey = publicKey
+      return { address: publicKey }
+    } catch (cause) {
+      throw this.mapLedgerError(cause)
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.transport) {
+      await this.transport.close().catch(() => undefined)
+    }
+    this.transport = null
+    this.app = null
+    this.publicKey = null
+  }
+
+  async signTransaction(xdr: string, opts?: SignTransactionOptions): Promise<string> {
+    if (!opts?.networkPassphrase) {
+      throw new WalletAdapterError('Ledger signing requires opts.networkPassphrase', 'INVALID_XDR')
+    }
+    if (!this.publicKey) {
+      throw new WalletAdapterError('Ledger not connected; call connect() first', 'CONNECTION_FAILED')
+    }
+
+    const app = await this.getApp()
+    try {
+      const tx = TransactionBuilder.fromXDR(xdr, opts.networkPassphrase)
+      const signatureBase = tx.signatureBase() as unknown as Uint8Array
+      // hw-app-str streams the signature base to the device in APDU chunks
+      // and prompts the user to review + approve the transaction on-screen.
+      const { signature } = await app.signTransaction(this.derivationPath, signatureBase)
+      tx.addSignature(this.publicKey, bytesToBase64(signature))
+      return tx.toXDR()
+    } catch (cause) {
+      throw this.mapLedgerError(cause)
+    }
+  }
+
+  private async getApp(): Promise<StrApp> {
+    if (this.app) return this.app
+    const transport = await this.getTransport()
+    const { default: Str } = await loadOptionalWalletDependency<{ default: new (transport: LedgerTransport) => StrApp }>(
+      APP_MODULE_NAME,
+      this.name,
+    )
+    this.app = new Str(transport)
+    return this.app
+  }
+
+  private async getTransport(): Promise<LedgerTransport> {
+    if (this.transport) return this.transport
+
+    const transport = await this.openWebHidOrWebUsb()
+    transport.on('disconnect', () => {
+      this.deviceDisconnected = true
+      this.transport = null
+      this.app = null
+    })
+    this.transport = transport
+    return transport
+  }
+
+  private async openWebHidOrWebUsb(): Promise<LedgerTransport> {
+    try {
+      const { default: TransportWebHID } = await loadOptionalWalletDependency<{ default: { create(): Promise<LedgerTransport> } }>(
+        WEBHID_MODULE_NAME,
+        this.name,
+      )
+      return await TransportWebHID.create()
+    } catch {
+      const { default: TransportWebUSB } = await loadOptionalWalletDependency<{ default: { create(): Promise<LedgerTransport> } }>(
+        WEBUSB_MODULE_NAME,
+        this.name,
+      )
+      return await TransportWebUSB.create()
+    }
+  }
+
+  /** Maps Ledger transport/device errors — including disconnection and on-device rejection — onto WalletAdapterError. */
+  private mapLedgerError(cause: unknown): WalletAdapterError {
+    if (cause instanceof WalletAdapterError) return cause
+    if (this.deviceDisconnected) {
+      return new WalletAdapterError('Ledger device disconnected', 'DEVICE_DISCONNECTED', cause)
+    }
+    const message = cause instanceof Error ? cause.message : String(cause)
+    if (/0x6985|denied|reject/i.test(message)) {
+      return new WalletAdapterError('Transaction rejected on Ledger device', 'USER_REJECTED', cause)
+    }
+    if (/disconnect/i.test(message)) {
+      return new WalletAdapterError('Ledger device disconnected', 'DEVICE_DISCONNECTED', cause)
+    }
+    return new WalletAdapterError(`Ledger request failed: ${message}`, 'CONNECTION_FAILED', cause)
+  }
+}

--- a/packages/sdk/src/lobstr-adapter.ts
+++ b/packages/sdk/src/lobstr-adapter.ts
@@ -1,0 +1,89 @@
+/**
+ * Lobstr Wallet Adapter
+ *
+ * Integrates the Lobstr browser extension via `lobstr-wallet-sdk`.
+ */
+
+import type { SorobanWalletAdapter, SignTransactionOptions, WalletConnectionResult } from './wallet-adapter.js'
+import { WalletAdapterError, loadOptionalWalletDependency } from './wallet-adapter.js'
+
+const MODULE_NAME = 'lobstr-wallet-sdk'
+
+/** Minimal shape of the Lobstr extension client used by this adapter. */
+interface LobstrClient {
+  getPublicKey(): Promise<string>
+  signTransaction(xdr: string, opts?: { network?: string }): Promise<string>
+  getNetwork?(): Promise<string>
+}
+
+interface LobstrModule {
+  default: new () => LobstrClient
+}
+
+export class LobstrAdapter implements SorobanWalletAdapter {
+  readonly id = 'lobstr'
+  readonly name = 'Lobstr'
+
+  private client: LobstrClient | null = null
+  private connectedPublicKey: string | null = null
+
+  async isAvailable(): Promise<boolean> {
+    return typeof window !== 'undefined'
+  }
+
+  async connect(): Promise<WalletConnectionResult> {
+    const client = await this.getClient()
+    try {
+      const publicKey = await client.getPublicKey()
+      this.connectedPublicKey = publicKey
+      const network = await this.detectNetwork(client)
+      return { address: publicKey, network }
+    } catch (cause) {
+      throw mapLobstrError(cause)
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    this.client = null
+    this.connectedPublicKey = null
+  }
+
+  async signTransaction(xdr: string, opts?: SignTransactionOptions): Promise<string> {
+    const client = await this.getClient()
+    try {
+      return await client.signTransaction(xdr, { network: opts?.networkPassphrase })
+    } catch (cause) {
+      throw mapLobstrError(cause)
+    }
+  }
+
+  /** Detects the network the Lobstr extension is currently connected to, when the SDK exposes it. */
+  private async detectNetwork(client: LobstrClient): Promise<string | undefined> {
+    if (!client.getNetwork) return undefined
+    try {
+      return await client.getNetwork()
+    } catch {
+      return undefined
+    }
+  }
+
+  private async getClient(): Promise<LobstrClient> {
+    if (this.client) return this.client
+    const mod = await loadOptionalWalletDependency<LobstrModule>(MODULE_NAME, this.name)
+    this.client = new mod.default()
+    return this.client
+  }
+}
+
+/** Maps Lobstr extension errors — including user rejections — onto WalletAdapterError. */
+function mapLobstrError(cause: unknown): WalletAdapterError {
+  if (cause instanceof WalletAdapterError) return cause
+  const message = cause instanceof Error ? cause.message : String(cause)
+  if (/reject|denied|cancel/i.test(message)) {
+    return new WalletAdapterError('User rejected the Lobstr request', 'USER_REJECTED', cause)
+  }
+  if (/not\s*installed|not\s*found|extension/i.test(message)) {
+    return new WalletAdapterError('Lobstr extension not detected', 'NOT_INSTALLED', cause)
+  }
+  return new WalletAdapterError(`Lobstr request failed: ${message}`, 'CONNECTION_FAILED', cause)
+}

--- a/packages/sdk/src/wallet-adapter.ts
+++ b/packages/sdk/src/wallet-adapter.ts
@@ -1,0 +1,88 @@
+/**
+ * Wallet Adapter Contract
+ *
+ * Common interface implemented by every supported wallet integration
+ * (xBull, Lobstr, WalletConnect, Ledger, ...) so callers can connect and
+ * sign Soroban transactions without depending on any single wallet's SDK.
+ */
+
+export interface SignTransactionOptions {
+  /** Network passphrase the transaction was built for. Required by adapters that must re-derive the signature base (e.g. hardware wallets). */
+  networkPassphrase?: string
+  /** Public key to sign with, when a wallet exposes multiple accounts. */
+  accountToSign?: string
+}
+
+export interface WalletConnectionResult {
+  /** Public key (G...) of the connected account. */
+  address: string
+  /** Network identifier reported by the wallet, when available. */
+  network?: string
+}
+
+/** Adapter contract implemented by each supported wallet integration. */
+export interface SorobanWalletAdapter {
+  readonly id: string
+  readonly name: string
+  /** Whether this wallet's runtime (extension, bridge, hardware transport) is detectable in the current environment. */
+  isAvailable(): Promise<boolean>
+  connect(): Promise<WalletConnectionResult>
+  disconnect(): Promise<void>
+  /** Signs a base64-encoded transaction envelope XDR and returns the signed XDR. */
+  signTransaction(xdr: string, opts?: SignTransactionOptions): Promise<string>
+}
+
+export type WalletAdapterErrorCode =
+  | 'NOT_INSTALLED'
+  | 'DEPENDENCY_NOT_INSTALLED'
+  | 'CONNECTION_FAILED'
+  | 'USER_REJECTED'
+  | 'DEVICE_DISCONNECTED'
+  | 'TIMEOUT'
+  | 'SESSION_EXPIRED'
+  | 'INVALID_XDR'
+
+/** Error raised by wallet adapters, with a stable `code` for programmatic handling. */
+export class WalletAdapterError extends Error {
+  constructor(
+    message: string,
+    public code: WalletAdapterErrorCode,
+    public cause?: unknown,
+  ) {
+    super(message)
+    this.name = 'WalletAdapterError'
+  }
+}
+
+/**
+ * Lazily imports an optional wallet-SDK peer dependency. Wallet SDKs are not
+ * bundled with @soroban-resurrect/sdk so consumers only pay for the wallets
+ * they actually use. Throws a WalletAdapterError with an actionable install
+ * hint if the package isn't installed.
+ *
+ * The module specifier is passed as a variable (not a string literal) so
+ * bundlers and the TypeScript compiler don't try to statically resolve
+ * these optional packages at build time.
+ */
+export async function loadOptionalWalletDependency<T = unknown>(moduleName: string, adapterName: string): Promise<T> {
+  try {
+    return (await import(moduleName)) as T
+  } catch (cause) {
+    throw new WalletAdapterError(
+      `${adapterName} requires the optional dependency "${moduleName}". Install it with: npm install ${moduleName}`,
+      'DEPENDENCY_NOT_INSTALLED',
+      cause,
+    )
+  }
+}
+
+/** Encodes raw bytes as base64, working in both browser (btoa) and Node (Buffer) runtimes without requiring @types/node. */
+export function bytesToBase64(bytes: Uint8Array): string {
+  const nodeBuffer = (globalThis as unknown as { Buffer?: { from(b: Uint8Array): { toString(enc: string): string } } }).Buffer
+  if (nodeBuffer) {
+    return nodeBuffer.from(bytes).toString('base64')
+  }
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}

--- a/packages/sdk/src/walletconnect-adapter.ts
+++ b/packages/sdk/src/walletconnect-adapter.ts
@@ -1,0 +1,218 @@
+/**
+ * WalletConnect v2 Adapter
+ *
+ * Integrates WalletConnect v2 via `@walletconnect/web3wallet`, using CAIP-2
+ * chain ids and CAIP-10 accounts to negotiate a session scoped to Soroban
+ * transaction signing. Pairing is initiated via a URI that mobile wallets
+ * scan as a QR code (rendered through the optional `@walletconnect/modal`
+ * package, or handed back via `onPairingUri` for custom UI).
+ */
+
+import type { SorobanWalletAdapter, SignTransactionOptions, WalletConnectionResult } from './wallet-adapter.js'
+import { WalletAdapterError, loadOptionalWalletDependency } from './wallet-adapter.js'
+
+const WEB3WALLET_MODULE_NAME = '@walletconnect/web3wallet'
+const CORE_MODULE_NAME = '@walletconnect/core'
+const QR_MODAL_MODULE_NAME = '@walletconnect/modal'
+
+/** CAIP-2 namespace and chain ids for the Stellar/Soroban networks. */
+export const STELLAR_CAIP2_NAMESPACE = 'stellar'
+export const STELLAR_MAINNET_CHAIN_ID = 'stellar:pubnet'
+export const STELLAR_TESTNET_CHAIN_ID = 'stellar:testnet'
+
+/** JSON-RPC methods and events exposed to the wallet for Soroban session requests. */
+export const SOROBAN_WC_METHODS = ['stellar_signXDR', 'stellar_signAndSubmitXDR'] as const
+export const SOROBAN_WC_EVENTS = ['accountsChanged', 'chainChanged'] as const
+
+export interface WalletMetadata {
+  name: string
+  description: string
+  url: string
+  icons: string[]
+}
+
+export interface WalletConnectAdapterConfig {
+  projectId: string
+  metadata: WalletMetadata
+  /** CAIP-2 chain id to request. Defaults to STELLAR_MAINNET_CHAIN_ID. */
+  chainId?: string
+  /** Show the official WalletConnect QR modal when pairing. Defaults to true. */
+  showQrModal?: boolean
+  /** Called with the pairing URI; useful for custom QR rendering when showQrModal is false. */
+  onPairingUri?: (uri: string) => void
+}
+
+interface SessionProposal {
+  id: number
+  params: unknown
+}
+
+interface SessionNamespace {
+  accounts: string[]
+  methods: string[]
+  events: string[]
+}
+
+interface WalletSession {
+  topic: string
+  namespaces: Record<string, SessionNamespace>
+}
+
+interface QrModal {
+  openModal(opts: { uri: string }): Promise<void>
+  closeModal(): void
+}
+
+interface Web3WalletClient {
+  core: { pairing: { create(): Promise<{ uri: string; topic: string }> } }
+  on(event: 'session_proposal', handler: (proposal: SessionProposal) => void): void
+  approveSession(params: { id: number; namespaces: Record<string, SessionNamespace & { chains: string[] }> }): Promise<WalletSession>
+  rejectSession(params: { id: number; reason: { code: number; message: string } }): Promise<void>
+  disconnectSession(params: { topic: string; reason: { code: number; message: string } }): Promise<void>
+  request<T>(params: { topic: string; chainId: string; request: { method: string; params: unknown } }): Promise<T>
+}
+
+/** Wallet adapter for WalletConnect v2, scoped to Soroban transaction signing. */
+export class WalletConnectAdapter implements SorobanWalletAdapter {
+  readonly id = 'walletconnect'
+  readonly name = 'WalletConnect'
+
+  private readonly chainId: string
+  private client: Web3WalletClient | null = null
+  private session: WalletSession | null = null
+  private qrModal: QrModal | null = null
+
+  constructor(private readonly config: WalletConnectAdapterConfig) {
+    this.chainId = config.chainId ?? STELLAR_MAINNET_CHAIN_ID
+  }
+
+  async isAvailable(): Promise<boolean> {
+    // WalletConnect works cross-platform via the relay network + QR pairing.
+    return true
+  }
+
+  async connect(): Promise<WalletConnectionResult> {
+    const client = await this.getClient()
+    try {
+      const { uri, topic } = await client.core.pairing.create()
+      await this.showPairingUri(uri)
+
+      const session = await this.awaitSessionApproval(client, topic)
+      this.session = session
+
+      const address = firstStellarAddress(session)
+      return { address, network: this.chainId }
+    } catch (cause) {
+      throw mapWalletConnectError(cause)
+    } finally {
+      this.qrModal?.closeModal()
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client && this.session) {
+      await this.client
+        .disconnectSession({ topic: this.session.topic, reason: { code: 6000, message: 'User disconnected' } })
+        .catch(() => undefined)
+    }
+    this.session = null
+  }
+
+  async signTransaction(xdr: string, opts?: SignTransactionOptions): Promise<string> {
+    if (!this.client || !this.session) {
+      throw new WalletAdapterError('WalletConnect session not established; call connect() first', 'CONNECTION_FAILED')
+    }
+    try {
+      return await this.client.request<string>({
+        topic: this.session.topic,
+        chainId: this.chainId,
+        request: { method: 'stellar_signXDR', params: { xdr, address: opts?.accountToSign } },
+      })
+    } catch (cause) {
+      throw mapWalletConnectError(cause)
+    }
+  }
+
+  private async showPairingUri(uri: string): Promise<void> {
+    if (this.config.showQrModal === false) {
+      this.config.onPairingUri?.(uri)
+      return
+    }
+    try {
+      const { WalletConnectModal } = await loadOptionalWalletDependency<{
+        WalletConnectModal: new (opts: { projectId: string; chains: string[] }) => QrModal
+      }>(QR_MODAL_MODULE_NAME, this.name)
+      this.qrModal = new WalletConnectModal({ projectId: this.config.projectId, chains: [this.chainId] })
+      await this.qrModal.openModal({ uri })
+    } finally {
+      this.config.onPairingUri?.(uri)
+    }
+  }
+
+  private awaitSessionApproval(client: Web3WalletClient, _pairingTopic: string): Promise<WalletSession> {
+    return new Promise((resolve, reject) => {
+      client.on('session_proposal', (proposal) => {
+        client
+          .approveSession({
+            id: proposal.id,
+            namespaces: {
+              [STELLAR_CAIP2_NAMESPACE]: {
+                chains: [this.chainId],
+                methods: [...SOROBAN_WC_METHODS],
+                events: [...SOROBAN_WC_EVENTS],
+                accounts: [],
+              },
+            },
+          })
+          .then(resolve)
+          .catch(async (cause) => {
+            await client.rejectSession({ id: proposal.id, reason: { code: 5000, message: 'User rejected' } })
+            reject(cause)
+          })
+      })
+    })
+  }
+
+  private async getClient(): Promise<Web3WalletClient> {
+    if (this.client) return this.client
+    const [{ Core }, { Web3Wallet }] = await Promise.all([
+      loadOptionalWalletDependency<{ Core: new (opts: { projectId: string }) => unknown }>(CORE_MODULE_NAME, this.name),
+      loadOptionalWalletDependency<{ Web3Wallet: { init(opts: { core: unknown; metadata: WalletMetadata }): Promise<Web3WalletClient> } }>(
+        WEB3WALLET_MODULE_NAME,
+        this.name,
+      ),
+    ])
+    const core = new Core({ projectId: this.config.projectId })
+    this.client = await Web3Wallet.init({ core, metadata: this.config.metadata })
+    return this.client
+  }
+}
+
+/** Extracts the first Stellar address from a session's CAIP-10 accounts (`stellar:pubnet:G...`). */
+function firstStellarAddress(session: WalletSession): string {
+  const caip10 = session.namespaces[STELLAR_CAIP2_NAMESPACE]?.accounts[0]
+  if (!caip10) {
+    throw new WalletAdapterError('WalletConnect session has no Stellar accounts', 'CONNECTION_FAILED')
+  }
+  const address = caip10.split(':')[2]
+  if (!address) {
+    throw new WalletAdapterError(`Malformed CAIP-10 account: ${caip10}`, 'CONNECTION_FAILED')
+  }
+  return address
+}
+
+/** Maps WalletConnect session/request errors — including rejections and expiry — onto WalletAdapterError. */
+function mapWalletConnectError(cause: unknown): WalletAdapterError {
+  if (cause instanceof WalletAdapterError) return cause
+  const message = cause instanceof Error ? cause.message : String(cause)
+  if (/reject|denied|declin/i.test(message)) {
+    return new WalletAdapterError('User rejected the WalletConnect request', 'USER_REJECTED', cause)
+  }
+  if (/expire/i.test(message)) {
+    return new WalletAdapterError('WalletConnect session expired', 'SESSION_EXPIRED', cause)
+  }
+  if (/timeout/i.test(message)) {
+    return new WalletAdapterError('WalletConnect request timed out', 'TIMEOUT', cause)
+  }
+  return new WalletAdapterError(`WalletConnect request failed: ${message}`, 'CONNECTION_FAILED', cause)
+}

--- a/packages/sdk/src/xbull-adapter.ts
+++ b/packages/sdk/src/xbull-adapter.ts
@@ -1,0 +1,82 @@
+/**
+ * xBull Wallet Adapter
+ *
+ * Integrates xBull via the `@xbull/wallet-connect` SDK, which communicates
+ * with the xBull extension/mobile app over its own postMessage bridge.
+ */
+
+import type { SorobanWalletAdapter, SignTransactionOptions, WalletConnectionResult } from './wallet-adapter.js'
+import { WalletAdapterError, loadOptionalWalletDependency } from './wallet-adapter.js'
+
+const MODULE_NAME = '@xbull/wallet-connect'
+
+/** Minimal shape of the xBull bridge client used by this adapter. */
+interface XBullClient {
+  connect(): Promise<{ publicKey: string }>
+  sign(xdr: string, opts?: { publicKey?: string; network?: string }): Promise<{ signedXdr: string }>
+}
+
+interface XBullModule {
+  default: new () => XBullClient
+}
+
+export class XBullAdapter implements SorobanWalletAdapter {
+  readonly id = 'xbull'
+  readonly name = 'xBull'
+
+  private client: XBullClient | null = null
+  private connectedPublicKey: string | null = null
+
+  async isAvailable(): Promise<boolean> {
+    return typeof window !== 'undefined'
+  }
+
+  async connect(): Promise<WalletConnectionResult> {
+    const client = await this.getClient()
+    try {
+      const { publicKey } = await client.connect()
+      this.connectedPublicKey = publicKey
+      return { address: publicKey }
+    } catch (cause) {
+      throw mapXBullError(cause)
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    this.client = null
+    this.connectedPublicKey = null
+  }
+
+  async signTransaction(xdr: string, opts?: SignTransactionOptions): Promise<string> {
+    const client = await this.getClient()
+    try {
+      const { signedXdr } = await client.sign(xdr, {
+        publicKey: opts?.accountToSign ?? this.connectedPublicKey ?? undefined,
+        network: opts?.networkPassphrase,
+      })
+      return signedXdr
+    } catch (cause) {
+      throw mapXBullError(cause)
+    }
+  }
+
+  private async getClient(): Promise<XBullClient> {
+    if (this.client) return this.client
+    const mod = await loadOptionalWalletDependency<XBullModule>(MODULE_NAME, this.name)
+    this.client = new mod.default()
+    return this.client
+  }
+}
+
+/** Maps xBull bridge errors — including user rejections — onto WalletAdapterError. */
+function mapXBullError(cause: unknown): WalletAdapterError {
+  if (cause instanceof WalletAdapterError) return cause
+  const message = cause instanceof Error ? cause.message : String(cause)
+  if (/reject|denied|cancel/i.test(message)) {
+    return new WalletAdapterError('User rejected the xBull request', 'USER_REJECTED', cause)
+  }
+  if (/not\s*installed|not\s*found|no\s*bridge/i.test(message)) {
+    return new WalletAdapterError('xBull extension not detected', 'NOT_INSTALLED', cause)
+  }
+  return new WalletAdapterError(`xBull request failed: ${message}`, 'CONNECTION_FAILED', cause)
+}


### PR DESCRIPTION
## Summary
- Adds a shared `SorobanWalletAdapter` interface (`packages/sdk/src/wallet-adapter.ts`) implemented by four new wallet adapters
- `XBullAdapter` — xBull bridge-based communication, error mapping for user rejections (#69)
- `LobstrAdapter` — Lobstr extension support with network detection (#70)
- `WalletConnectAdapter` — WalletConnect v2 via `@walletconnect/web3wallet`, CAIP-2/10 namespaces/accounts for Soroban, session proposal/pairing/approval handling, QR modal pairing (#71)
- `LedgerAdapter` — `@ledgerhq/hw-app-str` over WebHID (falling back to WebUSB), on-device transaction review/signing, disconnect handling (#72)
- Wallet SDKs are declared as optional `peerDependencies` and lazily `import()`ed per adapter, so consumers only pay for the wallets they actually use
- All adapters + the interface are re-exported from `packages/sdk/src/index.ts`

Closes #69
Closes #70
Closes #71
Closes #72

## Test plan
- [x] `npx tsc --noEmit` on `packages/sdk` confirms the new files (`wallet-adapter.ts`, `xbull-adapter.ts`, `lobstr-adapter.ts`, `walletconnect-adapter.ts`, `ledger-adapter.ts`) type-check cleanly (pre-existing unrelated errors in `soroban-resurrect.ts`/`types.ts` are on `main` prior to this change)
- Tests intentionally skipped per request