### PR TITLE
Multi-wallet management, session persistence, property & fuzz testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,24 @@ jobs:
       - run: npx tsc --noEmit -p packages/sdk/tsconfig.json
       - run: npx tsc --noEmit -p packages/react/tsconfig.json
 
+  fuzz:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [quality]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Fuzz XDR parsing (60s)
+        working-directory: packages/sdk
+        run: npm run test:fuzz
+
   coverage:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,3 +8,22 @@ export type {
 } from './types.js'
 export type { SorobanResurrectProviderProps } from './SorobanResurrectProvider.js'
 
+export { WalletProvider } from './wallet/WalletProvider.js'
+export { WalletContext } from './wallet/WalletContext.js'
+export { useWallets } from './wallet/useWallets.js'
+export { useActiveWallet } from './wallet/useActiveWallet.js'
+export type { UseActiveWalletReturn } from './wallet/useActiveWallet.js'
+export {
+  saveWalletSession,
+  loadWalletSession,
+  clearWalletSession,
+  DEFAULT_STORAGE_KEY,
+} from './wallet/storage.js'
+export type {
+  WalletAdapter,
+  WalletDescriptor,
+  StoredWalletSession,
+  WalletProviderProps,
+  WalletContextValue,
+} from './wallet/types.js'
+

--- a/packages/react/src/wallet/WalletContext.ts
+++ b/packages/react/src/wallet/WalletContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react'
+import type { WalletContextValue } from './types.js'
+
+export const WalletContext = createContext<WalletContextValue | null>(null)

--- a/packages/react/src/wallet/WalletProvider.tsx
+++ b/packages/react/src/wallet/WalletProvider.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { WalletContext } from './WalletContext.js'
+import { saveWalletSession, loadWalletSession, clearWalletSession, DEFAULT_STORAGE_KEY } from './storage.js'
+import type { WalletContextValue, WalletProviderProps } from './types.js'
+
+export function WalletProvider({
+  wallets,
+  sessionTimeoutMs,
+  storageKey = DEFAULT_STORAGE_KEY,
+  autoReconnect = true,
+  children,
+}: WalletProviderProps) {
+  const [activeWalletId, setActiveWalletId] = useState<string | null>(null)
+  const [publicKey, setPublicKey] = useState<string | null>(null)
+  const [connectedAt, setConnectedAt] = useState<number | null>(null)
+  const [isConnecting, setIsConnecting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const reconnectAttempted = useRef(false)
+
+  const walletsById = useMemo(() => new Map(wallets.map((w) => [w.id, w] as const)), [wallets])
+
+  const connect = useCallback(async (walletId: string) => {
+    const wallet = walletsById.get(walletId)
+    if (!wallet) {
+      const message = `Unknown wallet: ${walletId}`
+      setError(message)
+      throw new Error(message)
+    }
+
+    setIsConnecting(true)
+    setError(null)
+    try {
+      const available = await wallet.isAvailable()
+      if (!available) {
+        throw new Error(`Wallet "${wallet.name}" is not available`)
+      }
+      const { publicKey: key } = await wallet.connect()
+      const now = Date.now()
+      setActiveWalletId(wallet.id)
+      setPublicKey(key)
+      setConnectedAt(now)
+      saveWalletSession({ walletId: wallet.id, publicKey: key, connectedAt: now }, storageKey)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setError(message)
+      throw err
+    } finally {
+      setIsConnecting(false)
+    }
+  }, [walletsById, storageKey])
+
+  const connectWithFallback = useCallback(async (walletIds: string[]) => {
+    let lastError: unknown = new Error('No wallets provided in fallback chain')
+    for (const walletId of walletIds) {
+      try {
+        await connect(walletId)
+        return
+      } catch (err) {
+        lastError = err
+      }
+    }
+    const message = lastError instanceof Error ? lastError.message : String(lastError)
+    setError(message)
+    throw lastError instanceof Error ? lastError : new Error(message)
+  }, [connect])
+
+  const disconnect = useCallback(async () => {
+    const wallet = activeWalletId ? walletsById.get(activeWalletId) : null
+    try {
+      await wallet?.disconnect()
+    } finally {
+      setActiveWalletId(null)
+      setPublicKey(null)
+      setConnectedAt(null)
+      clearWalletSession(storageKey)
+    }
+  }, [activeWalletId, walletsById, storageKey])
+
+  const switchWallet = useCallback(async (walletId: string) => {
+    const current = activeWalletId ? walletsById.get(activeWalletId) : null
+    if (current) {
+      await current.disconnect().catch(() => {})
+    }
+    await connect(walletId)
+  }, [activeWalletId, walletsById, connect])
+
+  // Restore a persisted session on mount, if the wallet extension is still available.
+  useEffect(() => {
+    if (!autoReconnect || reconnectAttempted.current) return
+    reconnectAttempted.current = true
+
+    const session = loadWalletSession(storageKey, sessionTimeoutMs)
+    if (!session) return
+
+    const wallet = walletsById.get(session.walletId)
+    if (!wallet) {
+      clearWalletSession(storageKey)
+      return
+    }
+
+    void (async () => {
+      try {
+        const available = await wallet.isAvailable()
+        if (!available) {
+          clearWalletSession(storageKey)
+          return
+        }
+        const { publicKey: key } = await wallet.connect()
+        setActiveWalletId(wallet.id)
+        setPublicKey(key)
+        setConnectedAt(session.connectedAt)
+        saveWalletSession({ walletId: wallet.id, publicKey: key, connectedAt: session.connectedAt }, storageKey)
+      } catch {
+        clearWalletSession(storageKey)
+      }
+    })()
+  }, [autoReconnect, storageKey, sessionTimeoutMs, walletsById])
+
+  // Auto-disconnect once the session exceeds sessionTimeoutMs.
+  useEffect(() => {
+    if (!sessionTimeoutMs || connectedAt == null) return
+    const remaining = sessionTimeoutMs - (Date.now() - connectedAt)
+    const timer = setTimeout(() => {
+      void disconnect()
+    }, Math.max(remaining, 0))
+    return () => clearTimeout(timer)
+  }, [sessionTimeoutMs, connectedAt, disconnect])
+
+  const activeWallet = activeWalletId ? walletsById.get(activeWalletId) ?? null : null
+
+  const value = useMemo<WalletContextValue>(() => ({
+    wallets,
+    activeWallet,
+    publicKey,
+    isConnecting,
+    error,
+    connect,
+    connectWithFallback,
+    disconnect,
+    switchWallet,
+  }), [wallets, activeWallet, publicKey, isConnecting, error, connect, connectWithFallback, disconnect, switchWallet])
+
+  return (
+    <WalletContext.Provider value={value}>
+      {children}
+    </WalletContext.Provider>
+  )
+}

--- a/packages/react/src/wallet/storage.ts
+++ b/packages/react/src/wallet/storage.ts
@@ -1,0 +1,59 @@
+import type { StoredWalletSession } from './types.js'
+
+export const DEFAULT_STORAGE_KEY = 'soroban-resurrect:wallet-session'
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null
+  return window.localStorage
+}
+
+export function saveWalletSession(
+  session: StoredWalletSession,
+  storageKey: string = DEFAULT_STORAGE_KEY,
+): void {
+  const storage = getStorage()
+  if (!storage) return
+  try {
+    storage.setItem(storageKey, JSON.stringify(session))
+  } catch {
+    // storage unavailable (quota, private browsing, etc.) — session simply won't persist
+  }
+}
+
+/**
+ * Loads the persisted session, discarding (and clearing) it if it is older
+ * than `sessionTimeoutMs`.
+ */
+export function loadWalletSession(
+  storageKey: string = DEFAULT_STORAGE_KEY,
+  sessionTimeoutMs?: number,
+): StoredWalletSession | null {
+  const storage = getStorage()
+  if (!storage) return null
+  try {
+    const raw = storage.getItem(storageKey)
+    if (!raw) return null
+    const session = JSON.parse(raw) as StoredWalletSession
+    if (typeof session?.walletId !== 'string' || typeof session?.publicKey !== 'string') {
+      storage.removeItem(storageKey)
+      return null
+    }
+    if (sessionTimeoutMs != null && Date.now() - session.connectedAt > sessionTimeoutMs) {
+      storage.removeItem(storageKey)
+      return null
+    }
+    return session
+  } catch {
+    return null
+  }
+}
+
+export function clearWalletSession(storageKey: string = DEFAULT_STORAGE_KEY): void {
+  const storage = getStorage()
+  if (!storage) return
+  try {
+    storage.removeItem(storageKey)
+  } catch {
+    // ignore
+  }
+}

--- a/packages/react/src/wallet/types.ts
+++ b/packages/react/src/wallet/types.ts
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Adapter contract that any wallet integration (Freighter, xBull, Albedo, …)
+ * must implement to plug into the wallet registry.
+ */
+export interface WalletAdapter {
+  id: string
+  name: string
+  icon?: string
+  isAvailable(): boolean | Promise<boolean>
+  connect(): Promise<{ publicKey: string }>
+  disconnect(): Promise<void>
+  signTransaction(txXDR: string, opts?: { networkPassphrase?: string }): Promise<string>
+}
+
+export interface WalletDescriptor {
+  id: string
+  name: string
+  icon?: string
+  isAvailable: boolean
+}
+
+export interface StoredWalletSession {
+  walletId: string
+  publicKey: string
+  connectedAt: number
+}
+
+export interface WalletProviderProps {
+  /** All wallet adapters this dApp supports. */
+  wallets: WalletAdapter[]
+  /** Auto-disconnect after this many ms of an established session. */
+  sessionTimeoutMs?: number
+  /** localStorage key used to persist the active session. Defaults to a namespaced key. */
+  storageKey?: string
+  /** Attempt to restore a persisted session on mount. Defaults to `true`. */
+  autoReconnect?: boolean
+  children: ReactNode
+}
+
+export interface WalletContextValue {
+  wallets: WalletAdapter[]
+  activeWallet: WalletAdapter | null
+  publicKey: string | null
+  isConnecting: boolean
+  error: string | null
+  /** Connect to a specific wallet by id. */
+  connect(walletId: string): Promise<void>
+  /** Try each wallet id in order, stopping at the first successful connection. */
+  connectWithFallback(walletIds: string[]): Promise<void>
+  disconnect(): Promise<void>
+  /** Disconnect the active wallet (if any) and connect to a different one. */
+  switchWallet(walletId: string): Promise<void>
+}

--- a/packages/react/src/wallet/useActiveWallet.ts
+++ b/packages/react/src/wallet/useActiveWallet.ts
@@ -1,0 +1,33 @@
+'use client'
+
+import { useContext } from 'react'
+import { WalletContext } from './WalletContext.js'
+import type { WalletAdapter } from './types.js'
+
+export interface UseActiveWalletReturn {
+  wallet: WalletAdapter | null
+  publicKey: string | null
+  isConnecting: boolean
+  error: string | null
+  connect: (walletId: string) => Promise<void>
+  connectWithFallback: (walletIds: string[]) => Promise<void>
+  disconnect: () => Promise<void>
+  switchWallet: (walletId: string) => Promise<void>
+}
+
+/** Returns the currently active wallet plus connection controls. */
+export function useActiveWallet(): UseActiveWalletReturn {
+  const ctx = useContext(WalletContext)
+  if (!ctx) throw new Error('useActiveWallet must be used within a WalletProvider')
+
+  return {
+    wallet: ctx.activeWallet,
+    publicKey: ctx.publicKey,
+    isConnecting: ctx.isConnecting,
+    error: ctx.error,
+    connect: ctx.connect,
+    connectWithFallback: ctx.connectWithFallback,
+    disconnect: ctx.disconnect,
+    switchWallet: ctx.switchWallet,
+  }
+}

--- a/packages/react/src/wallet/useWallets.ts
+++ b/packages/react/src/wallet/useWallets.ts
@@ -1,0 +1,35 @@
+'use client'
+
+import { useContext, useEffect, useState } from 'react'
+import { WalletContext } from './WalletContext.js'
+import type { WalletDescriptor } from './types.js'
+
+/**
+ * Returns every registered wallet adapter along with its live availability
+ * (e.g. whether the browser extension is installed).
+ */
+export function useWallets(): WalletDescriptor[] {
+  const ctx = useContext(WalletContext)
+  if (!ctx) throw new Error('useWallets must be used within a WalletProvider')
+
+  const [availability, setAvailability] = useState<Record<string, boolean>>({})
+
+  useEffect(() => {
+    let cancelled = false
+    void Promise.all(
+      ctx.wallets.map(async (wallet) => [wallet.id, await wallet.isAvailable()] as const),
+    ).then((entries) => {
+      if (!cancelled) setAvailability(Object.fromEntries(entries))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [ctx.wallets])
+
+  return ctx.wallets.map((wallet) => ({
+    id: wallet.id,
+    name: wallet.name,
+    icon: wallet.icon,
+    isAvailable: availability[wallet.id] ?? false,
+  }))
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -47,13 +47,17 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --config vitest.integration.ts",
+    "test:property": "vitest run tests/property",
+    "test:fuzz": "jazzer tests/fuzz/xdr-parsing.fuzz.ts --fuzz_function=fuzz -- -max_total_time=60",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0"
   },
   "devDependencies": {
+    "@jazzer.js/core": "^2.1.0",
     "@vitest/coverage-v8": "^2.0.0",
+    "fast-check": "^3.19.0",
     "tsup": "^8.3.0",
     "vitest": "^2.0.0"
   },

--- a/packages/sdk/tests/fuzz/xdr-parsing.fuzz.ts
+++ b/packages/sdk/tests/fuzz/xdr-parsing.fuzz.ts
@@ -1,0 +1,65 @@
+/**
+ * Coverage-guided fuzz target for XDR parsing (issue #76).
+ *
+ * Run locally with:
+ *   npx jazzer tests/fuzz/xdr-parsing.fuzz.ts --fuzz_function=fuzz -- -max_total_time=60
+ *
+ * Feeds `extractFootprintFromTransaction` and `classifyLedgerKey` random byte
+ * sequences, truncated XDR, and edge-case strings, asserting the SDK never
+ * crashes and never throws anything other than `SorobanResurrectError`.
+ */
+import { extractFootprintFromTransaction, classifyLedgerKey } from '../../src/footprint-parser.js'
+import { SorobanResurrectError } from '../../src/types.js'
+import { xdr } from '@stellar/stellar-sdk'
+
+const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015'
+
+function toEdgeCaseString(data: Buffer): string {
+  // Interpret the fuzzer bytes as base64 text, which is what real XDR
+  // payloads look like on the wire — this keeps the input distribution
+  // close to malformed-but-plausible transaction envelopes.
+  return data.toString('base64')
+}
+
+/** Builds a malformed LedgerKey-like object out of raw fuzzer bytes. */
+function toMalformedLedgerKey(data: Buffer): xdr.LedgerKey {
+  const discriminants = ['contractData', 'contractCode', 'ttl', 'account', 'trustline', '']
+  const tag = discriminants[data.length > 0 ? data[0] % discriminants.length : 0]
+
+  return {
+    switch: () => tag,
+    contractData: () => ({
+      contract: () => ({ contractId: () => data.subarray(1, 33) }),
+      key: () => ({
+        switch: () => ({ value: data.length > 1 ? data[1] : 0 }),
+        value: () => data.subarray(2),
+      }),
+      durability: () => ({ value: data.length > 2 ? data[2] : 0 }),
+    }),
+    contractCode: () => ({ hash: () => data.subarray(1, 33) }),
+  } as unknown as xdr.LedgerKey
+}
+
+export function fuzz(data: Buffer): void {
+  const txXDR = toEdgeCaseString(data)
+
+  // extractFootprintFromTransaction already wraps everything in try/catch and
+  // returns null on failure — it must never throw or crash the process.
+  try {
+    extractFootprintFromTransaction(txXDR, NETWORK_PASSPHRASE)
+  } catch (err) {
+    if (!(err instanceof SorobanResurrectError)) {
+      throw new Error(`extractFootprintFromTransaction threw a non-SorobanResurrectError: ${String(err)}`)
+    }
+  }
+
+  // classifyLedgerKey should degrade to keyType "unknown" rather than throw
+  // for any malformed key shape.
+  try {
+    classifyLedgerKey(toMalformedLedgerKey(data))
+  } catch (err) {
+    if (!(err instanceof SorobanResurrectError)) {
+      throw new Error(`classifyLedgerKey threw a non-SorobanResurrectError: ${String(err)}`)
+    }
+  }
+}

--- a/packages/sdk/tests/property/footprint-parser.property.test.ts
+++ b/packages/sdk/tests/property/footprint-parser.property.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Property-based tests (issue #75) verifying invariants of the footprint
+ * parsing/classification helpers using fast-check.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import fc from 'fast-check'
+import { classifyLedgerKey, classifySacKey, extractKeysFromFootprint } from '../../src/footprint-parser.js'
+import { SorobanResurrectError } from '../../src/types.js'
+import { xdr } from '@stellar/stellar-sdk'
+
+// ---------------------------------------------------------------------------
+// Mock stellar-sdk to keep property tests hermetic (mirrors tests/sac-contract-data.test.ts)
+// ---------------------------------------------------------------------------
+
+vi.mock('@stellar/stellar-sdk', () => {
+  class MockScVal {
+    constructor(private _typeValue: number, private _val?: unknown) {}
+    switch() {
+      return { value: this._typeValue, name: `type_${this._typeValue}` }
+    }
+    value() {
+      return this._val
+    }
+  }
+
+  const SCV_SYMBOL = 15
+  const SCV_VEC = 16
+  const SCV_LEDGER_KEY_NONCE = 21
+  const SCV_LEDGER_KEY_CONTRACT_INSTANCE = 20
+
+  const scvSymbol = (s: string) => new MockScVal(SCV_SYMBOL, Buffer.from(s))
+  const scvVec = (items: MockScVal[]) => new MockScVal(SCV_VEC, items)
+  const scvLedgerKeyContractInstance = () => new MockScVal(SCV_LEDGER_KEY_CONTRACT_INSTANCE)
+  const scvLedgerKeyNonce = () => new MockScVal(SCV_LEDGER_KEY_NONCE, {})
+
+  const makeLedgerKey = (entryType: string, overrides: Record<string, () => unknown> = {}) => ({
+    switch: () => entryType,
+    contractData: () => ({
+      contract: () => ({ contractId: () => Buffer.from('cafebabe', 'hex') }),
+      key: overrides.key ?? (() => scvLedgerKeyContractInstance()),
+      durability: () => ({ value: 1 }),
+    }),
+    contractCode: () => ({ hash: () => Buffer.from('deadbeef', 'hex') }),
+    ...overrides,
+  })
+
+  return {
+    xdr: {
+      LedgerEntryType: {
+        contractData: () => 'contractData',
+        contractCode: () => 'contractCode',
+        ttl: () => 'ttl',
+      },
+      ScValType: {
+        scvSymbol: () => ({ value: SCV_SYMBOL }),
+        scvVec: () => ({ value: SCV_VEC }),
+        scvLedgerKeyNonce: () => ({ value: SCV_LEDGER_KEY_NONCE }),
+        scvLedgerKeyContractInstance: () => ({ value: SCV_LEDGER_KEY_CONTRACT_INSTANCE }),
+      },
+      ScVal: { scvSymbol, scvVec, scvLedgerKeyContractInstance, scvLedgerKeyNonce },
+      _makeLedgerKey: makeLedgerKey,
+      _scvSymbol: scvSymbol,
+      _scvVec: scvVec,
+    },
+    SorobanRpc: { Server: vi.fn(), Api: {} },
+    TransactionBuilder: { fromXDR: vi.fn() },
+    Transaction: vi.fn(),
+    Operation: { restoreFootprint: vi.fn() },
+    Account: vi.fn(),
+    BASE_FEE: '100',
+    SorobanDataBuilder: vi.fn(),
+  }
+})
+
+function makeContractDataKey(scVal: unknown): xdr.LedgerKey {
+  return (xdr as any)._makeLedgerKey('contractData', { key: () => scVal }) as unknown as xdr.LedgerKey
+}
+
+// A minimal footprint stand-in; only readOnly()/readWrite() are exercised by
+// extractKeysFromFootprint.
+function makeFootprint(readOnly: unknown[], readWrite: unknown[]): xdr.LedgerFootprint {
+  return {
+    readOnly: () => readOnly,
+    readWrite: () => readWrite,
+  } as unknown as xdr.LedgerFootprint
+}
+
+describe('property: classifySacKey', () => {
+  const KNOWN_SYMBOL_KEYS: Record<string, string> = {
+    Admin: 'sacAdmin',
+    Name: 'sacMetadata',
+    Symbol: 'sacMetadata',
+    Decimals: 'sacMetadata',
+  }
+
+  it('maps every known scvSymbol key to its documented sacKeyType', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...Object.keys(KNOWN_SYMBOL_KEYS)), (sym) => {
+        const scVal = (xdr as any)._scvSymbol(sym)
+        expect(classifySacKey(scVal)).toBe(KNOWN_SYMBOL_KEYS[sym])
+      }),
+    )
+  })
+
+  it('never returns a sacKeyType for arbitrary unknown symbol strings', () => {
+    fc.assert(
+      fc.property(
+        fc.string().filter((s) => !(s in KNOWN_SYMBOL_KEYS)),
+        (sym) => {
+          const scVal = (xdr as any)._scvSymbol(sym)
+          expect(classifySacKey(scVal)).toBeUndefined()
+        },
+      ),
+    )
+  })
+
+  it('is a pure function: identical input always yields identical output', () => {
+    fc.assert(
+      fc.property(fc.string(), (sym) => {
+        const a = classifySacKey((xdr as any)._scvSymbol(sym))
+        const b = classifySacKey((xdr as any)._scvSymbol(sym))
+        expect(a).toBe(b)
+      }),
+    )
+  })
+})
+
+describe('property: classifyLedgerKey', () => {
+  it('is deterministic/idempotent for any given key', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('contractData', 'contractCode', 'ttl', 'account'), (entryType) => {
+        const key = (xdr as any)._makeLedgerKey(entryType) as unknown as xdr.LedgerKey
+        const first = classifyLedgerKey(key)
+        const second = classifyLedgerKey(key)
+        expect(second).toEqual(first)
+      }),
+    )
+  })
+
+  it('always assigns contractInstance entries restorePriority 0 and everything else > 0', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('contractData', 'contractCode', 'ttl', 'account'), (entryType) => {
+        const key = (xdr as any)._makeLedgerKey(entryType) as unknown as xdr.LedgerKey
+        const { keyType, restorePriority } = classifyLedgerKey(key)
+        if (keyType === 'contractInstance') {
+          expect(restorePriority).toBe(0)
+        } else {
+          expect(restorePriority).toBeGreaterThan(0)
+        }
+      }),
+    )
+  })
+
+  it('SAC keys built from arbitrary vec symbols only ever classify as balance/allowance/undefined', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('Balance', 'Allowance', 'Other'), (sym) => {
+        const vec = (xdr as any)._scvVec([(xdr as any)._scvSymbol(sym)])
+        const key = makeContractDataKey(vec)
+        const { sacKeyType } = classifyLedgerKey(key)
+        if (sym === 'Balance') expect(sacKeyType).toBe('sacBalance')
+        else if (sym === 'Allowance') expect(sacKeyType).toBe('sacAllowance')
+        else expect(sacKeyType).toBeUndefined()
+      }),
+    )
+  })
+})
+
+describe('property: extractKeysFromFootprint', () => {
+  it('readOnly and readWrite are always disjoint and `all` is their concatenation', () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 10 }), fc.nat({ max: 10 }), (roCount, rwCount) => {
+        const readOnly = Array.from({ length: roCount }, (_, i) => ({ tag: `ro-${i}` }))
+        const readWrite = Array.from({ length: rwCount }, (_, i) => ({ tag: `rw-${i}` }))
+        const footprint = makeFootprint(readOnly, readWrite)
+
+        const result = extractKeysFromFootprint(footprint)
+
+        expect(result.readOnly).toHaveLength(roCount)
+        expect(result.readWrite).toHaveLength(rwCount)
+        expect(result.all).toHaveLength(roCount + rwCount)
+        expect(result.all).toEqual([...result.readOnly, ...result.readWrite])
+
+        const roSet = new Set(result.readOnly)
+        const rwSet = new Set(result.readWrite)
+        for (const key of roSet) expect(rwSet.has(key)).toBe(false)
+      }),
+    )
+  })
+})
+
+describe('property: SorobanResurrectError codes are unique', () => {
+  it('has no duplicate error codes across the documented union', () => {
+    const codes = [
+      'SIMULATION_FAILED',
+      'RESTORE_FAILED',
+      'ORIGINAL_TX_FAILED',
+      'NO_ACCOUNT',
+      'INVALID_XDR',
+      'ARCHIVE_DETECTION_FAILED',
+      'NETWORK_ERROR',
+    ] as const
+
+    expect(new Set(codes).size).toBe(codes.length)
+
+    for (const code of codes) {
+      const err = new SorobanResurrectError(`test ${code}`, code)
+      expect(err.code).toBe(code)
+      expect(err).toBeInstanceOf(Error)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- **#73 Multi-wallet state management** — `WalletProvider`, `useWallets()`, `useActiveWallet()` with `switchWallet()`, `connectWithFallback()` fallback chains, and localStorage-backed preference persistence.
- **#74 Wallet session persistence** — sessions (publicKey, wallet id, connectedAt) persist across reloads, auto-reconnect on mount (skipped if the wallet extension is no longer available), `sessionTimeoutMs` auto-disconnect, and explicit `disconnect()` clears storage.
- **#75 Property-based testing** — `fast-check` added to `packages/sdk`, with property tests covering `classifySacKey` determinism/round-trip, `classifyLedgerKey` invariants (restore priority, idempotence), `extractKeysFromFootprint` readOnly/readWrite disjointness, and uniqueness of `SorobanResurrectError` codes.
- **#76 Fuzz testing** — `@jazzer.js/core` fuzz target for `extractFootprintFromTransaction` and `classifyLedgerKey` against random bytes/truncated XDR/edge-case strings, asserting no crashes and no non-`SorobanResurrectError` throws; wired into CI as a 60s job on every PR.

Closes #73, closes #74, closes #75, closes #76

## Test plan
- [ ] `npm install` to pull in `fast-check` and `@jazzer.js/core`
- [ ] `npm run test:property -w packages/sdk`
- [ ] `npm run test:fuzz -w packages/sdk`
- [ ] `npm run typecheck -w packages/react`
- [ ] Manually exercise `WalletProvider` + `useWallets`/`useActiveWallet` against a real wallet adapter (e.g. Freighter) in the example app